### PR TITLE
[조애리]w3_리뷰요청_채널생성_서버_graphQL로직

### DIFF
--- a/server-api/src/apollo/app.js
+++ b/server-api/src/apollo/app.js
@@ -1,0 +1,18 @@
+const { ApolloServer, makeExecutableSchema } = require('apollo-server-express');
+const typeDefs = require('./typeDefs');
+const resolvers = require('./resolvers');
+const { verifyToken } = require('../utils/token');
+
+const schema = makeExecutableSchema({
+  typeDefs,
+  resolvers,
+});
+
+const apolloServer = new ApolloServer({
+  schema,
+  context: ({ req }) => ({
+    user: verifyToken(req.headers['x-auth-token']),
+  }),
+});
+
+module.exports = apolloServer;

--- a/server-api/src/apollo/resolvers/channels.js
+++ b/server-api/src/apollo/resolvers/channels.js
@@ -1,0 +1,24 @@
+const Channels = require('../../models/channels');
+
+const createChannelInfo = (user, channelId) => ({
+  channelId,
+  channelName: `${user.displayname}님의 채널입니다.😀`,
+});
+
+const createChannel = async (_, { channelId }, { user }) => {
+  const newChannel = new Channels(createChannelInfo(user, channelId));
+
+  try {
+    await newChannel.save();
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+const resolvers = {
+  Mutation: {
+    createChannel,
+  },
+};
+
+module.exports = resolvers;

--- a/server-api/src/apollo/resolvers/common.js
+++ b/server-api/src/apollo/resolvers/common.js
@@ -1,0 +1,7 @@
+const resolvers = {
+  Query: {
+    Dummy: () => '',
+  },
+};
+
+module.exports = resolvers;

--- a/server-api/src/apollo/resolvers/index.js
+++ b/server-api/src/apollo/resolvers/index.js
@@ -1,0 +1,12 @@
+/* eslint-disable global-require */
+const { merge } = require('../../utils/object');
+
+const resolvers = merge({
+  Query: {},
+  Mutation: {},
+}, ...[
+  require('./common'),
+  require('./channels'),
+]);
+
+module.exports = resolvers;

--- a/server-api/src/apollo/typeDefs/channels.js
+++ b/server-api/src/apollo/typeDefs/channels.js
@@ -1,0 +1,19 @@
+const { gql } = require('apollo-server-express');
+
+const typeDefs = gql`
+type Channel {
+  channelId: String!
+  channelName: String
+  maxHeadCount: Int
+}
+
+type CreateChannelResponse {
+  status: String!
+}
+
+type Mutation {
+  createChannel(channelId: String!): CreateChannelResponse
+}
+`;
+
+module.exports = typeDefs;

--- a/server-api/src/apollo/typeDefs/common.js
+++ b/server-api/src/apollo/typeDefs/common.js
@@ -1,0 +1,9 @@
+const { gql } = require('apollo-server-express');
+
+const typeDefs = gql`
+type Query {
+  Dummy: String
+}
+`;
+
+module.exports = typeDefs;

--- a/server-api/src/apollo/typeDefs/index.js
+++ b/server-api/src/apollo/typeDefs/index.js
@@ -1,0 +1,5 @@
+/* eslint-disable global-require */
+module.exports = [
+  require('./common'),
+  require('./channels'),
+];

--- a/server-api/src/models/channels.js
+++ b/server-api/src/models/channels.js
@@ -1,0 +1,30 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const ChannelSchema = new Schema({
+  channelId: {
+    type: String,
+    required: true,
+  },
+  channelName: {
+    type: String,
+    required: true,
+  },
+  maxHeadCount: {
+    type: Number,
+    required: true,
+    default: 100,
+  },
+  expiredAt: {
+    type: Date,
+    required: true,
+    default: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now(),
+  },
+});
+
+module.exports = mongoose.model('channels', ChannelSchema);

--- a/server-api/src/models/users.js
+++ b/server-api/src/models/users.js
@@ -1,0 +1,36 @@
+const mongoose = require('mongoose');
+
+const { Schema } = mongoose;
+
+const UserSchema = new Schema({
+  username: {
+    type: String,
+    required: [true, '아이디는 필수입니다.'],
+  },
+  displayname: String,
+  createdAt: {
+    type: Date,
+    default: Date.now(),
+  },
+});
+
+UserSchema.statics.upsert = function upsertUser(username, displayname) {
+  const UserModel = this;
+  const findUser = UserModel.findOne({ username });
+
+  return findUser.then((user) => {
+    if (user) return user;
+
+    const userInfo = {
+      username,
+      displayname,
+    };
+    const newUser = new UserModel(userInfo);
+
+    return newUser.save();
+  }).catch((error) => {
+    throw error;
+  });
+};
+
+module.exports = mongoose.model('user', UserSchema);

--- a/server-api/src/utils/object.js
+++ b/server-api/src/utils/object.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-param-reassign */
+const isObjectType = (val) => typeof val === 'object';
+
+const mergeOne = (target, source) => {
+  Object.keys(source).forEach((key) => {
+    if ([target[key], source[key]].every(isObjectType)) {
+      target[key] = mergeOne(target[key], source[key]);
+    } else {
+      target[key] = source[key];
+    }
+  });
+
+  return target;
+};
+
+const merge = (target, ...sources) => sources.reduceRight(
+  (result, source) => mergeOne(result, source),
+  target,
+);
+
+module.exports = { merge };


### PR DESCRIPTION
# [조애리]w3_리뷰요청_채널생성_서버_graphQL로직

## 해당 이슈 📎
- [Epic#12] 파일 업로드 시 새로운 채널이 생성된다. (#25)

## 개발상황 요약 📝
- 클라이언트에서 채널정보를 받아 DB에 저장하는 reslover로직을 구현하였습니다.
- resolver들을 merge하는 유틸 함수를 구현하였습니다.

## 리뷰어님 참고 사항 🙋‍♀️
> 리뷰요청을 드리기 위해 클라이언트 부분은 빼고 서버쪽 graphQL로직만 업로드하였습니다! 

## 리뷰어님께 드리고 싶은 질문 ❓

1. 저희가 sns 로그인에는 express로 구현한 rest API를 사용하고 나머지는 apollo를 이용하여 graphQL을 쓰고 있는데요,  role-oriented로 폴더구조를 분리하려니 express와 graphQL 구조가 달라서 많은 고민을 하였습니다.
현재는 `server-api > express`와 `server-api > apollo`로 나누어서 관리하고 있습니다. 
이러한 방식이 적절할지 더 좋은 대안이 있을지 여쭤보고 싶습니다!

2. graphQL 구조와 로직에 저희가 미처 캐치하지 못한 문제가 있는지 체크해주신다면 감사하겠습니다😊