### PR TITLE
채팅을 공감순/최신순으로 정렬

### DIFF
--- a/server-api/src/models/chats.js
+++ b/server-api/src/models/chats.js
@@ -26,7 +26,7 @@ const ChatSchema = new Schema({
   },
   createdAt: {
     type: Date,
-    default: Date.now(),
+    default: Date.now,
   },
 });
 

--- a/web/src/components/channel/Chat/Chat.jsx
+++ b/web/src/components/channel/Chat/Chat.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ChatInput from './ChatInput';
 import ChatLogs from './ChatLogs';
+import ChatSort from './ChatSort';
 import S from './style';
 import { useInitChatLogs, useGetUserStatus } from '@/hooks';
 
@@ -12,6 +13,7 @@ const Chat = ({ channelId }) => {
 
   return (
     <S.Chat>
+      <ChatSort channelId={channelId} />
       <ChatLogs channelId={channelId} userId={userId} />
       <ChatInput channelId={channelId} />
     </S.Chat>

--- a/web/src/components/channel/Chat/ChatInput/ChatInput.jsx
+++ b/web/src/components/channel/Chat/ChatInput/ChatInput.jsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import S from './style';
 import { useAddChat } from '@/hooks';
+import { CHAT_INPUT_PLACEHOLDER } from '@/constants';
+import S from './style';
 
 const KEYCODE_ENTER = 13;
 
@@ -28,7 +29,7 @@ const ChatInput = (props) => {
   return (
     <S.ChatInput>
       <S.MessageInput
-        placeholder="의견을 남겨주세요."
+        placeholder={CHAT_INPUT_PLACEHOLDER}
         onChange={handleChangeInput}
         onKeyDown={handleKeyDownInput}
         value={message}

--- a/web/src/components/channel/Chat/ChatInput/style.jsx
+++ b/web/src/components/channel/Chat/ChatInput/style.jsx
@@ -8,6 +8,7 @@ const S = {
     width: 100%;
     height: ${px(124)};
     padding: ${px(9)} ${px(12)} ${px(9)} ${px(16)};
+    border-top: ${px(1)} solid ${colorGray(1)};
     border-radius: ${px(3)};
     box-shadow: 0 ${px(2)} ${px(20)} rgba(0, 0, 0, 0.03);
     background-color: #fff;

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
@@ -3,24 +3,27 @@ import PropTypes from 'prop-types';
 import ChatCard from './ChatCard';
 import { useGetChatsCached } from '@/hooks';
 import { computeScrollEndTop } from '@/utils/dom';
+import { CHAT_ADDED } from '@/constants';
 import S from './style';
 
 const ChatCards = (props) => {
   const scrollWrapRef = useRef(null);
   const { userId } = props;
-  const chatLogs = useGetChatsCached();
+  const { logs, changeType } = useGetChatsCached();
 
   useEffect(() => {
+    if (changeType !== CHAT_ADDED) return;
+
     const scrollWrapEl = scrollWrapRef.current;
     const endTop = computeScrollEndTop(scrollWrapEl);
 
     scrollWrapRef.current.scrollTop = endTop;
-  }, [chatLogs]);
+  }, [logs]);
 
   return (
     <S.ScrollWrap ref={scrollWrapRef}>
       <S.Scroller>
-        {chatLogs.map(({
+        {logs.map(({
           id,
           author,
           message,

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
@@ -11,8 +11,8 @@ const ChatCards = (props) => {
   const { userId } = props;
   const { logs, changeType, sortType } = useGetChatsCached();
   const sortCallback = sortType === CHAT_SORT_BY_LIKE
-    ? (a, b) => b.likes.length - a.likes.length
-    : (a, b) => a.createdAt - b.createdAt;
+    ? (prev, next) => next.likes.length - prev.likes.length
+    : (prev, next) => prev.createdAt - next.createdAt;
   const chatLogs = logs.sort(sortCallback);
   const changeScrollTop = () => {
     const scrollWrapEl = scrollWrapRef.current;

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import ChatCard from './ChatCard';
+import { useGetChatsCached } from '@/hooks';
+import { computeScrollEndTop } from '@/utils/dom';
+import S from './style';
+
+const ChatCards = (props) => {
+  const scrollWrapRef = useRef(null);
+  const { userId } = props;
+  const chatLogs = useGetChatsCached();
+
+  useEffect(() => {
+    const scrollWrapEl = scrollWrapRef.current;
+    const endTop = computeScrollEndTop(scrollWrapEl);
+
+    scrollWrapRef.current.scrollTop = endTop;
+  }, [chatLogs]);
+
+  return (
+    <S.ScrollWrap ref={scrollWrapRef}>
+      <S.Scroller>
+        {chatLogs.map(({
+          id,
+          author,
+          message,
+          likes,
+        }) => (
+          <S.ChatLog key={`chat-log-${id}`}>
+            <ChatCard
+              id={id}
+              author={author}
+              message={message}
+              isLiked={likes.includes(userId)}
+              likesCount={likes.length}
+            />
+          </S.ChatLog>
+        ))}
+      </S.Scroller>
+    </S.ScrollWrap>
+  );
+};
+
+ChatCards.propTypes = {
+  userId: PropTypes.string.isRequired,
+};
+
+export default ChatCards;

--- a/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
@@ -1,45 +1,17 @@
-import React, { useRef, useEffect } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useChatChanged } from '@/hooks';
-import ChatCard from './ChatCard';
+import ChatCards from './ChatCards';
 import S from './style';
-import { computeScrollEndTop } from '@/utils/dom';
 
 const ChatLogs = (props) => {
-  const scrollWrapRef = useRef(null);
   const { channelId, userId } = props;
-  const { data } = useChatChanged(channelId);
-  const chatLogs = data;
 
-  useEffect(() => {
-    const scrollWrapEl = scrollWrapRef.current;
-    const endTop = computeScrollEndTop(scrollWrapEl);
-
-    scrollWrapRef.current.scrollTop = endTop;
-  }, [chatLogs]);
+  useChatChanged(channelId);
 
   return (
     <S.ChatLogs>
-      <S.ScrollWrap ref={scrollWrapRef}>
-        <S.Scroller>
-          {chatLogs.map(({
-            id,
-            author,
-            message,
-            likes,
-          }) => (
-            <S.ChatLog key={`chat-log-${id}`}>
-              <ChatCard
-                id={id}
-                author={author}
-                message={message}
-                isLiked={likes.includes(userId)}
-                likesCount={likes.length}
-              />
-            </S.ChatLog>
-          ))}
-        </S.Scroller>
-      </S.ScrollWrap>
+      <ChatCards userId={userId} />
     </S.ChatLogs>
   );
 };

--- a/web/src/components/channel/Chat/ChatSort/ChatSort.jsx
+++ b/web/src/components/channel/Chat/ChatSort/ChatSort.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import S from './style';
+
+const ChatSort = () => (
+  <S.ChatSort>
+    <S.SortButton aria-selected="true">최신순</S.SortButton>
+    <S.SortButton>공감순</S.SortButton>
+  </S.ChatSort>
+);
+
+export default ChatSort;

--- a/web/src/components/channel/Chat/ChatSort/ChatSort.jsx
+++ b/web/src/components/channel/Chat/ChatSort/ChatSort.jsx
@@ -1,11 +1,34 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { useChangeChatSort } from '@/hooks';
+import { CHAT_SORT_BY_RECENT, CHAT_SORT_BY_LIKE } from '@/constants';
 import S from './style';
 
-const ChatSort = () => (
-  <S.ChatSort>
-    <S.SortButton aria-selected="true">최신순</S.SortButton>
-    <S.SortButton>공감순</S.SortButton>
-  </S.ChatSort>
-);
+const ChatSort = () => {
+  const [sortType, setSortType] = useState(CHAT_SORT_BY_RECENT);
+  const changeSort = useChangeChatSort();
+  const handleClick = (targetSortType) => {
+    if (sortType === targetSortType) return;
+
+    changeSort(targetSortType);
+    setSortType(targetSortType);
+  };
+
+  return (
+    <S.ChatSort>
+      <S.SortButton
+        aria-selected={sortType === CHAT_SORT_BY_RECENT}
+        onClick={() => handleClick(CHAT_SORT_BY_RECENT)}
+      >
+        최신순
+      </S.SortButton>
+      <S.SortButton
+        aria-selected={sortType === CHAT_SORT_BY_LIKE}
+        onClick={() => handleClick(CHAT_SORT_BY_LIKE)}
+      >
+        공감순
+      </S.SortButton>
+    </S.ChatSort>
+  );
+};
 
 export default ChatSort;

--- a/web/src/components/channel/Chat/ChatSort/index.js
+++ b/web/src/components/channel/Chat/ChatSort/index.js
@@ -1,0 +1,1 @@
+export { default } from './ChatSort';

--- a/web/src/components/channel/Chat/ChatSort/style.jsx
+++ b/web/src/components/channel/Chat/ChatSort/style.jsx
@@ -1,0 +1,30 @@
+import styled from 'styled-components';
+import { px, colorGray, colorYellow } from '@/styles';
+
+const S = {
+  ChatSort: styled.div`
+    flex: 0 0 auto;
+    height: ${px(35)};
+    padding: ${px(5)} ${px(20)};
+    border-radius: ${px(3)};
+    border-bottom: ${px(1)} solid ${colorGray(1)};
+    box-shadow: 0px 2px 9px rgba(0, 0, 0, 0.03);
+    background-color: #fff;
+  `,
+  SortButton: styled.button.attrs({ type: 'button' })`
+    float: right;
+    font-size: ${px(14)};
+    line-height: ${px(25)};
+    vertical-align: top;
+    color: ${colorGray(8)};
+    & + & {
+      margin-right: ${px(8)};
+    }
+    &[aria-selected="true"] {
+      color: ${colorYellow(9)}
+    }
+    cursor: pointer;
+  `,
+};
+
+export default S;

--- a/web/src/constants/chat.js
+++ b/web/src/constants/chat.js
@@ -1,2 +1,3 @@
 export const CHAT_ADDED = 'CHAT_ADDED';
 export const CHAT_UPDATED = 'CHAT_UPDATED';
+export const CHAT_INPUT_PLACEHOLDER = '질문을 남겨주세요.';

--- a/web/src/constants/chat.js
+++ b/web/src/constants/chat.js
@@ -1,3 +1,5 @@
 export const CHAT_ADDED = 'CHAT_ADDED';
 export const CHAT_UPDATED = 'CHAT_UPDATED';
+export const CHAT_SORT_BY_RECENT = 'CHAT_SORT_BY_RECENT';
+export const CHAT_SORT_BY_LIKE = 'CHAT_SORT_BY_LIKE';
 export const CHAT_INPUT_PLACEHOLDER = '질문을 남겨주세요.';

--- a/web/src/constants/chat.js
+++ b/web/src/constants/chat.js
@@ -1,0 +1,2 @@
+export const CHAT_ADDED = 'CHAT_ADDED';
+export const CHAT_UPDATED = 'CHAT_UPDATED';

--- a/web/src/constants/index.js
+++ b/web/src/constants/index.js
@@ -1,2 +1,3 @@
 export * from './api';
 export * from './main';
+export * from './chat';

--- a/web/src/graphql/index.js
+++ b/web/src/graphql/index.js
@@ -2,6 +2,7 @@ import { ApolloClient } from 'apollo-client';
 import link from './link';
 import cache from './cache';
 import resolvers from './resolvers';
+import { CHAT_SORT_BY_RECENT } from '@/constants';
 
 const token = localStorage.getItem('DROPY_TOKEN');
 const tokenAnonymous = localStorage.getItem('DROPY_ANONYMOUS_TOKEN');
@@ -22,6 +23,7 @@ const defaultCacheData = {
     logs: [],
     cached: false,
     changeType: null,
+    sortType: CHAT_SORT_BY_RECENT,
   },
 };
 

--- a/web/src/graphql/index.js
+++ b/web/src/graphql/index.js
@@ -21,6 +21,7 @@ const defaultCacheData = {
     __typename: 'chatLogs',
     logs: [],
     cached: false,
+    changeType: null,
   },
 };
 

--- a/web/src/hooks/index.js
+++ b/web/src/hooks/index.js
@@ -9,3 +9,4 @@ export { default as useCheckChannel } from './useCheckChannel';
 export { default as useCheckAndLoginAnonymous } from './useCheckAndLoginAnonymous';
 export { default as useInitChatLogs } from './useInitChatLogs';
 export { default as useChannelSelector } from './useChannelSelector';
+export { default as useGetChatsCached } from './useGetChatsCached';

--- a/web/src/hooks/index.js
+++ b/web/src/hooks/index.js
@@ -11,3 +11,4 @@ export { default as useInitChatLogs } from './useInitChatLogs';
 export { default as useChannelSelector } from './useChannelSelector';
 export { default as useGetChatsCached } from './useGetChatsCached';
 export { default as useInitChatCached } from './useInitChatCached';
+export { default as useChangeChatSort } from './useChangeChatSort';

--- a/web/src/hooks/index.js
+++ b/web/src/hooks/index.js
@@ -10,3 +10,4 @@ export { default as useCheckAndLoginAnonymous } from './useCheckAndLoginAnonymou
 export { default as useInitChatLogs } from './useInitChatLogs';
 export { default as useChannelSelector } from './useChannelSelector';
 export { default as useGetChatsCached } from './useGetChatsCached';
+export { default as useInitChatCached } from './useInitChatCached';

--- a/web/src/hooks/useChangeChatSort.js
+++ b/web/src/hooks/useChangeChatSort.js
@@ -1,0 +1,21 @@
+import { useApolloClient } from '@apollo/react-hooks';
+import { GET_CHAT_CACHED } from './useChatChanged';
+
+const useChangeChatSort = () => {
+  const client = useApolloClient();
+  const changeSortType = (sortType) => {
+    const { chatLogs } = client.readQuery({ query: GET_CHAT_CACHED });
+    const data = {
+      chatLogs: {
+        ...chatLogs,
+        sortType,
+      },
+    };
+
+    client.writeQuery({ query: GET_CHAT_CACHED, data });
+  };
+
+  return changeSortType;
+};
+
+export default useChangeChatSort;

--- a/web/src/hooks/useChatChanged.js
+++ b/web/src/hooks/useChatChanged.js
@@ -11,6 +11,7 @@ const GET_CHAT_CACHED = gql`
       logs
       cached
       changeType
+      sortType
     }
   }
 `;
@@ -25,19 +26,18 @@ const CHAT_CHANGED = gql`
       }
       message
       likes
+      createdAt
     }
   }
 `;
 
 const addOrUpdateChat = (cacheData, chat) => {
-  const { chatLogs: { logs, cached, changeType } } = cacheData;
-  const indexOfChat = logs.findIndex(({ id }) => id === chat.id);
+  const { chatLogs } = cacheData;
+  const indexOfChat = chatLogs.logs.findIndex(({ id }) => id === chat.id);
   const newData = {
     chatLogs: {
-      __typename: 'chatLogs',
-      logs: [...logs],
-      cached,
-      changeType,
+      ...chatLogs,
+      logs: [...chatLogs.logs],
     },
   };
 

--- a/web/src/hooks/useChatChanged.js
+++ b/web/src/hooks/useChatChanged.js
@@ -48,7 +48,7 @@ const useChatChanged = (channelId) => {
   const queryResult = useQuery(GET_CHAT_CACHED);
   const logs = queryResult.data ? queryResult.data.chatLogs.logs : [];
 
-  if (!chatChanged) return { data: logs };
+  if (!chatChanged) return;
 
   const newLogs = addOrUpdateChat(logs, chatChanged);
   const data = {
@@ -60,8 +60,6 @@ const useChatChanged = (channelId) => {
   };
 
   client.writeQuery({ query: GET_CHAT_CACHED, data });
-
-  return { data: newLogs };
 };
 
 export { GET_CHAT_CACHED };

--- a/web/src/hooks/useChatChanged.js
+++ b/web/src/hooks/useChatChanged.js
@@ -2,14 +2,15 @@ import gql from 'graphql-tag';
 import {
   useSubscription,
   useApolloClient,
-  useQuery,
 } from '@apollo/react-hooks';
+import { CHAT_ADDED, CHAT_UPDATED } from '@/constants';
 
 const GET_CHAT_CACHED = gql`
   query GetChatCached {
     chatLogs @client {
       logs
       cached
+      changeType
     }
   }
 `;
@@ -28,36 +29,38 @@ const CHAT_CHANGED = gql`
   }
 `;
 
-const addOrUpdateChat = (chatLogs, chat) => {
-  const indexOfChat = chatLogs.findIndex(({ id }) => id === chat.id);
-  const newChatLogs = [...chatLogs];
+const addOrUpdateChat = (cacheData, chat) => {
+  const { chatLogs: { logs, cached, changeType } } = cacheData;
+  const indexOfChat = logs.findIndex(({ id }) => id === chat.id);
+  const newData = {
+    chatLogs: {
+      __typename: 'chatLogs',
+      logs: [...logs],
+      cached,
+      changeType,
+    },
+  };
 
   if (indexOfChat === -1) {
-    newChatLogs.push(chat);
+    newData.chatLogs.logs.push(chat);
+    newData.chatLogs.changeType = CHAT_ADDED;
   } else {
-    newChatLogs.splice(indexOfChat, 1, chat);
+    newData.chatLogs.logs.splice(indexOfChat, 1, chat);
+    newData.chatLogs.changeType = CHAT_UPDATED;
   }
 
-  return newChatLogs;
+  return newData;
 };
 
 const useChatChanged = (channelId) => {
   const client = useApolloClient();
   const published = useSubscription(CHAT_CHANGED, { variables: { channelId } });
   const chatChanged = published.data && published.data.chatChanged;
-  const queryResult = useQuery(GET_CHAT_CACHED);
-  const logs = queryResult.data ? queryResult.data.chatLogs.logs : [];
 
   if (!chatChanged) return;
 
-  const newLogs = addOrUpdateChat(logs, chatChanged);
-  const data = {
-    chatLogs: {
-      __typename: 'chatLogs',
-      logs: newLogs,
-      cached: queryResult.data.chatLogs.cached,
-    },
-  };
+  const cacheData = client.readQuery({ query: GET_CHAT_CACHED });
+  const data = addOrUpdateChat(cacheData, chatChanged);
 
   client.writeQuery({ query: GET_CHAT_CACHED, data });
 };

--- a/web/src/hooks/useGetChatsCached.js
+++ b/web/src/hooks/useGetChatsCached.js
@@ -1,0 +1,11 @@
+import { useQuery } from '@apollo/react-hooks';
+import { GET_CHAT_CACHED } from './useChatChanged';
+
+const useGetChatsCached = () => {
+  const { data } = useQuery(GET_CHAT_CACHED);
+  const chatLogs = data ? data.chatLogs.logs : [];
+
+  return chatLogs;
+};
+
+export default useGetChatsCached;

--- a/web/src/hooks/useGetChatsCached.js
+++ b/web/src/hooks/useGetChatsCached.js
@@ -2,10 +2,14 @@ import { useQuery } from '@apollo/react-hooks';
 import { GET_CHAT_CACHED } from './useChatChanged';
 
 const useGetChatsCached = () => {
-  const { data } = useQuery(GET_CHAT_CACHED);
-  const chatLogs = data ? data.chatLogs.logs : [];
+  const queryResult = useQuery(GET_CHAT_CACHED);
+  const data = queryResult.data ? queryResult.data.chatLogs : {
+    logs: [],
+    cached: false,
+    changeType: null,
+  };
 
-  return chatLogs;
+  return data;
 };
 
 export default useGetChatsCached;

--- a/web/src/hooks/useGetChatsCached.js
+++ b/web/src/hooks/useGetChatsCached.js
@@ -1,5 +1,6 @@
 import { useQuery } from '@apollo/react-hooks';
 import { GET_CHAT_CACHED } from './useChatChanged';
+import { CHAT_SORT_BY_RECENT } from '@/constants';
 
 const useGetChatsCached = () => {
   const queryResult = useQuery(GET_CHAT_CACHED);
@@ -7,6 +8,7 @@ const useGetChatsCached = () => {
     logs: [],
     cached: false,
     changeType: null,
+    sortType: CHAT_SORT_BY_RECENT,
   };
 
   return data;

--- a/web/src/hooks/useInitChatCached.js
+++ b/web/src/hooks/useInitChatCached.js
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useApolloClient } from '@apollo/react-hooks';
+import { GET_CHAT_CACHED } from './useChatChanged';
+
+const useInitChatChached = () => {
+  const client = useApolloClient();
+  const data = {
+    chatLogs: {
+      __typename: 'chatLogs',
+      logs: [],
+      cached: false,
+      changeType: null,
+    },
+  };
+
+  useEffect(() => {
+    client.writeQuery({ query: GET_CHAT_CACHED, data });
+  }, []);
+};
+
+export default useInitChatChached;

--- a/web/src/hooks/useInitChatCached.js
+++ b/web/src/hooks/useInitChatCached.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useApolloClient } from '@apollo/react-hooks';
 import { GET_CHAT_CACHED } from './useChatChanged';
+import { CHAT_SORT_BY_RECENT } from '@/constants';
 
 const useInitChatChached = () => {
   const client = useApolloClient();
@@ -10,6 +11,7 @@ const useInitChatChached = () => {
       logs: [],
       cached: false,
       changeType: null,
+      sortType: CHAT_SORT_BY_RECENT,
     },
   };
 

--- a/web/src/hooks/useInitChatLogs.js
+++ b/web/src/hooks/useInitChatLogs.js
@@ -13,6 +13,7 @@ const INIT_CHAT_LOGS = gql`
       }
       message
       likes
+      createdAt
     }
   }
 `;
@@ -20,26 +21,25 @@ const INIT_CHAT_LOGS = gql`
 const useInitChatLogs = (channelId) => {
   const client = useApolloClient();
   const result = useQuery(INIT_CHAT_LOGS, { variables: { channelId } });
-  const chatLogs = result.data ? result.data.getChatLogs : [];
+  const chatLogsCached = result.data ? result.data.getChatLogs : [];
 
   useEffect(() => {
-    const { chatLogs: { logs, cached, changeType } } = client.readQuery({ query: GET_CHAT_CACHED });
+    const { chatLogs } = client.readQuery({ query: GET_CHAT_CACHED });
 
-    if (result.loading || cached) return;
+    if (result.loading || chatLogs.cached) return;
 
     const data = {
       chatLogs: {
-        __typename: 'chatLogs',
-        logs: [...chatLogs, ...logs],
+        ...chatLogs,
+        logs: [...chatLogsCached, ...chatLogs.logs],
         cached: true,
-        changeType,
       },
     };
 
     client.writeQuery({ query: GET_CHAT_CACHED, data });
   }, [result.loading]);
 
-  return chatLogs;
+  return chatLogsCached;
 };
 
 export default useInitChatLogs;

--- a/web/src/hooks/useInitChatLogs.js
+++ b/web/src/hooks/useInitChatLogs.js
@@ -23,7 +23,7 @@ const useInitChatLogs = (channelId) => {
   const chatLogs = result.data ? result.data.getChatLogs : [];
 
   useEffect(() => {
-    const { chatLogs: { logs, cached } } = client.readQuery({ query: GET_CHAT_CACHED });
+    const { chatLogs: { logs, cached, changeType } } = client.readQuery({ query: GET_CHAT_CACHED });
 
     if (result.loading || cached) return;
 
@@ -32,6 +32,7 @@ const useInitChatLogs = (channelId) => {
         __typename: 'chatLogs',
         logs: [...chatLogs, ...logs],
         cached: true,
+        changeType,
       },
     };
 

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import { useRouteMatch } from 'react-router-dom';
 import { ChannelContext } from '@/contexts';
-import { useCheckChannel, useCheckAndLoginAnonymous } from '@/hooks';
+import {
+  useCheckChannel,
+  useCheckAndLoginAnonymous,
+  useInitChatCached,
+} from '@/hooks';
 import { Chat, Slide, ToolBar } from '@/components/channel';
 import S from './style';
 
@@ -9,6 +13,7 @@ const Channel = () => {
   const { params: { channelId } } = useRouteMatch();
   const { data } = useCheckChannel(channelId);
 
+  useInitChatCached();
   useCheckAndLoginAnonymous();
 
   if (!data) return null;


### PR DESCRIPTION
# 채팅을 공감순/최신순으로 정렬

## 해당 이슈 📎

- [Epic#16] 채팅을 공감순/최신순으로 정렬할 수 있다. (#45)

## 변경 사항 🛠

- 채팅 컴포넌트와 hook을 분리시켜서 렌더링 최적화
- 채널 접속시 채팅에 대한 캐시를 초기화
- 채팅 소팅 기능 추가

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음
