### PR TITLE
[조애리]w4_리뷰요청_슬라이드_컴포넌트_구현

### DIFF
--- a/server-api/src/apollo/resolvers/channels.js
+++ b/server-api/src/apollo/resolvers/channels.js
@@ -1,0 +1,137 @@
+const { withFilter, ApolloError } = require('apollo-server-express');
+const Channels = require('../../models/channels');
+const Histories = require('../../models/histories');
+const Users = require('../../models/users');
+
+const SLIDE_CHANGED = 'SLIDE_CHANGED';
+
+const createChannelInfo = (
+  user,
+  channelId,
+  channelCode,
+  slideUrls,
+  fileUrl,
+) => ({
+  channelId,
+  channelCode,
+  channelName: `${user.displayName}님의 채널입니다😀`,
+  masterId: user.userId,
+  slideUrls,
+  fileUrl,
+});
+
+const createChannel = async (_, {
+  channelId,
+  channelCode,
+  slideUrls,
+  fileUrl,
+}, { user }) => {
+  const newChannel = new Channels(
+    createChannelInfo(
+      user,
+      channelId,
+      channelCode,
+      slideUrls,
+      fileUrl,
+    ),
+  );
+  const updatedAt = Date.now();
+  const { userId } = user;
+  const masterId = userId;
+  const newHistory = new Histories({
+    userId,
+    masterId,
+    channelId,
+    updatedAt,
+  });
+
+  try {
+    const channel = await newChannel.save();
+    const payload = await channel.toPayload({ master: user });
+
+    await newHistory.save();
+
+    return { status: 'ok', channel: payload };
+  } catch (err) {
+    throw new ApolloError(err.message);
+  }
+};
+
+const getChannel = async (_, { channelId }, { user }) => {
+  try {
+    const channel = await Channels.findOne({ channelId });
+    const master = await Users.findOne({ userId: channel.masterId });
+    const status = channel ? 'ok' : 'not_exist';
+    const isMaster = !!channel && !!user && channel.masterId === user.userId;
+
+    if (!channel) return { status, isMaster };
+
+    const payload = await channel.toPayload({ master });
+
+    return {
+      status,
+      isMaster,
+      channel: payload,
+    };
+  } catch (err) {
+    throw new ApolloError(err.message);
+  }
+};
+
+const getChannelsByCode = async (_, { channelCode }) => {
+  try {
+    const channels = await Channels.find({ channelCode });
+    const status = channels ? 'ok' : 'not_exist';
+    const refindedChannels = channels.map(async (channel) => {
+      const master = await Users.findOne({ userId: channel.masterId });
+      return channel.toPayload({ master });
+    });
+
+    return {
+      status,
+      channels: refindedChannels,
+    };
+  } catch (err) {
+    throw new ApolloError(err.message);
+  }
+};
+
+const setCurrentSlide = async (_, { channelId, currentSlide }, { user, pubsub }) => {
+  try {
+    const channel = await Channels.findOneAndUpdate(
+      { channelId },
+      { currentSlide },
+      { new: true },
+    );
+    const payload = await channel.toPayload({ master: user });
+
+    pubsub.publish(SLIDE_CHANGED, { slideChanged: payload });
+
+    return payload;
+  } catch (err) {
+    throw new ApolloError(err.message);
+  }
+};
+
+const slideChanged = {
+  subscribe: withFilter(
+    (_, __, { pubsub }) => pubsub.asyncIterator(SLIDE_CHANGED),
+    (payload, variables) => payload.slideChanged.channelId === variables.channelId,
+  ),
+};
+
+const resolvers = {
+  Query: {
+    getChannel,
+    getChannelsByCode,
+  },
+  Mutation: {
+    createChannel,
+    setCurrentSlide,
+  },
+  Subscription: {
+    slideChanged,
+  },
+};
+
+module.exports = resolvers;

--- a/server-api/src/apollo/typeDefs/channels.js
+++ b/server-api/src/apollo/typeDefs/channels.js
@@ -1,0 +1,50 @@
+const typeDefs = `
+type Channel {
+  channelId: String
+  master: User 
+  channelName: String
+  maxHeadCount: Int
+  slideUrls: [String]
+  fileUrl: String
+  channelCode: String!
+  channelStatus: String
+  currentSlide: Int!
+}
+
+type getChannelResponse {
+  status: String!
+  isMaster: Boolean!
+  channel: Channel
+}
+
+type CreateChannelResponse {
+  status: String!
+  channel: Channel
+}
+
+type getChannelsByCodeResponse {
+  status: String!
+  channels: [Channel]
+}
+
+extend type Query {
+  getChannelsByCode(channelCode: String!): getChannelsByCodeResponse
+  getChannel(channelId: String!): getChannelResponse
+}
+
+extend type Mutation {
+  createChannel(
+    channelId: String!, 
+    channelCode: String!,
+    slideUrls: [String], 
+    fileUrl: String,
+  ): CreateChannelResponse,
+  setCurrentSlide(channelId: String!, currentSlide: Int!): Channel
+}
+
+extend type Subscription {
+  slideChanged(channelId: String!): Channel
+}
+`;
+
+module.exports = typeDefs;

--- a/server-api/src/models/channels.js
+++ b/server-api/src/models/channels.js
@@ -1,0 +1,73 @@
+const mongoose = require('mongoose');
+const Users = require('./users');
+const { assignFilter } = require('../utils/object');
+
+const { Schema } = mongoose;
+
+const ChannelSchema = new Schema({
+  channelId: {
+    type: String,
+    required: true,
+  },
+  channelCode: {
+    type: String,
+    required: true,
+  },
+  masterId: {
+    type: String,
+    required: true,
+  },
+  channelName: {
+    type: String,
+    required: true,
+  },
+  maxHeadCount: {
+    type: Number,
+    required: true,
+    default: 100,
+  },
+  expiredAt: {
+    type: Date,
+    required: true,
+    default: Date.now() + 30 * 24 * 60 * 60 * 1000,
+  },
+  slideUrls: {
+    type: Array,
+  },
+  fileUrl: {
+    type: String,
+  },
+  channelStatus: {
+    type: String,
+    required: true,
+    default: 'on',
+  },
+  currentSlide: {
+    type: Number,
+    required: true,
+    default: 0,
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now(),
+  },
+});
+
+ChannelSchema.methods.toPayload = async function toChannelPayload(...objs) {
+  const channel = this;
+  const master = await Users.findOne({ userId: channel.masterId });
+
+  return assignFilter([
+    'channelId',
+    'master',
+    'channelName',
+    'maxHeadCount',
+    'slideUrls',
+    'fileUrl',
+    'channelStatus',
+    'currentSlide',
+    'channelCode',
+  ], channel, { master }, ...objs);
+};
+
+module.exports = mongoose.model('channels', ChannelSchema);

--- a/server-converter/src/@types/express.d.ts
+++ b/server-converter/src/@types/express.d.ts
@@ -1,0 +1,15 @@
+import { Request, Response, NextFunction } from 'express';
+import { SlideInfo } from './converter';
+
+declare global {
+  namespace Express {
+      interface Request {
+          slides: SlideInfo[]
+          fileUrl: string
+          slideUrls: string[]
+      }
+  }
+}
+
+export type RequestHandler = (req: Request, res: Response, next: NextFunction) => any;
+export type MulterHandler = (req: Request, file: Express.Multer.File, callback: any) => any;

--- a/server-converter/src/app.ts
+++ b/server-converter/src/app.ts
@@ -1,0 +1,53 @@
+import * as express from 'express';
+import * as cors from 'cors';
+import {
+  auth,
+  convert,
+  upload,
+  saveTmp,
+  removeTmp,
+} from './middlewares';
+
+const app = express();
+
+const corsOption = {
+  origin: true,
+  methods: 'GET,HEAD,PUT,PATCH,POST,DELETE',
+  credentials: true,
+  exposedHeaders: ['x-auth-token'],
+};
+
+const handleError: express.ErrorRequestHandler = (err, _, res, __) => {
+  const status = 'error';
+  const message = (typeof err === 'string') ? err : err.message;
+
+  res.status(500)
+    .json({ status, message });
+};
+
+const start = () => {
+  app.use(cors(corsOption));
+  app.use(express.json());
+  app.use(auth);
+  app.post(
+    '/images',
+    saveTmp,
+    convert,
+    upload,
+    removeTmp,
+    (req, res) => {
+      const { slideUrls, fileUrl } = req;
+      res.status(200).json({
+        status: 'ok',
+        slideUrls,
+        fileUrl,
+      });
+    },
+  );
+  app.use(handleError);
+  app.listen('3000', () => {
+    console.log('welcome dropy converter!');
+  });
+};
+
+export default { start };

--- a/server-converter/src/middlewares/upload.ts
+++ b/server-converter/src/middlewares/upload.ts
@@ -1,0 +1,59 @@
+import * as AwsSdk from 'aws-sdk';
+import { createReadStream, read } from 'fs';
+import { RequestHandler } from '../@types';
+
+const s3 = new AwsSdk.S3({
+  endpoint: process.env.NCS_ENDPOINT,
+  accessKeyId: process.env.NCS_ACCESS_KEY,
+  secretAccessKey: process.env.NCS_SECRET_KEY,
+  region: process.env.NCS_REGION,
+});
+
+const uploadToObjectStorage = (
+  filePath: string,
+  channelId: string,
+  name: string,
+  isFile: boolean,
+): Promise<string> => new Promise((resolve, reject) => {
+  const readStream = createReadStream(filePath);
+  const params = {
+    Bucket: process.env.NCS_BUCKET,
+    Key: `${channelId}/${isFile ? 'files' : 'slides'}/${name}`,
+    ACL: 'public-read',
+    Body: readStream,
+  };
+
+  s3.upload(params, (err: any, data) => {
+    readStream.destroy();
+    if (err) reject(err);
+    else resolve(data.Location);
+  });
+});
+
+const uploadMiddleware: RequestHandler = (req, _, next) => {
+  const { channelId } = req.body;
+  const uploadFile: Promise<string> = uploadToObjectStorage(
+    req.file.path,
+    channelId,
+    'index',
+    true,
+  );
+  const uploadSlides: Promise<string>[] = req.slides.map((slide) => uploadToObjectStorage(
+    slide.path,
+    channelId,
+    `${slide.page}`,
+    false,
+  ));
+
+  Promise.all([uploadFile, ...uploadSlides])
+    .then((locations) => {
+      req.fileUrl = locations.shift();
+      req.slideUrls = locations;
+      next();
+    })
+    .catch((err) => {
+      throw new Error(err);
+    });
+};
+
+export default uploadMiddleware;

--- a/web/src/components/channel/Slide/Slide.jsx
+++ b/web/src/components/channel/Slide/Slide.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useSlideChanged } from '@/hooks';
+import S from './style';
+import SlideStatus from './SlideStatus';
+import SlideViewer from './SlideViewer';
+import SlideInfo from './SlideInfo';
+
+const Slide = (props) => {
+  const { channelId } = props;
+  const { currentSlide } = useSlideChanged(channelId);
+  const [isSync, setSync] = useState(true);
+  const [page, setPage] = useState(0);
+  const handleSync = (state) => () => {
+    setPage(currentSlide);
+    setSync(state);
+  };
+
+  return (
+    <S.Slide>
+      <SlideStatus
+        isSync={isSync}
+        handleSync={handleSync}
+      />
+      <SlideViewer
+        isSync={isSync}
+        setSync={setSync}
+        page={page}
+        setPage={setPage}
+        channelId={channelId}
+      />
+      <SlideInfo />
+    </S.Slide>
+  );
+};
+
+Slide.propTypes = {
+  channelId: PropTypes.string.isRequired,
+};
+
+export default Slide;

--- a/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import S from './style';
+import { useChannelSelector } from '@/hooks';
+
+const SlideInfo = () => {
+  const channelName = useChannelSelector((state) => state.channelName);
+  const masterName = useChannelSelector((state) => state.masterName);
+
+  return (
+    <S.SlideInfo>
+      <S.TitleWrapper>
+        <S.ChannelTitle>{channelName}</S.ChannelTitle>
+        <S.MasterName>
+          <span>| &nbsp;&nbsp;</span>
+          {masterName}
+        </S.MasterName>
+      </S.TitleWrapper>
+    </S.SlideInfo>
+  );
+};
+
+export default SlideInfo;

--- a/web/src/components/channel/Slide/SlideInfo/index.js
+++ b/web/src/components/channel/Slide/SlideInfo/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlideInfo';

--- a/web/src/components/channel/Slide/SlideInfo/style.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/style.jsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { colorGray, px } from '@/styles/themeUtil';
+
+export default {
+  SlideInfo: styled.div`
+    height: ${px(142)};
+    width:94%;
+    border-top: 1px solid ${colorGray(3)};
+    padding: ${px(15)} 0 0 ${px(20)};
+  `,
+  TitleWrapper: styled.div`
+    display: flex;
+    align-items:center;
+  `,
+  ChannelTitle: styled.h1`
+    font-size: ${px(24)};
+    color: ${colorGray(7)};
+    font-weight: 400;
+    margin-right: ${px(20)};
+  `,
+  MasterName: styled.h3`
+    font-size: ${px(18)};
+    color: ${colorGray(7)};
+    font-weight: 400;
+  `,
+};

--- a/web/src/components/channel/Slide/SlideStatus/FullScreenButton/FullScreenButton.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/FullScreenButton/FullScreenButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SmallButton } from '@/components/common';
+
+const FullScreenButton = () => (
+  <SmallButton>
+    <span aria-label="sync" role="img">🎬</span>
+    전체화면
+  </SmallButton>
+);
+
+
+export default FullScreenButton;

--- a/web/src/components/channel/Slide/SlideStatus/FullScreenButton/index.js
+++ b/web/src/components/channel/Slide/SlideStatus/FullScreenButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './FullScreenButton';

--- a/web/src/components/channel/Slide/SlideStatus/NoteButton/NoteButton.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/NoteButton/NoteButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SmallButton } from '@/components/common';
+
+const NoteButton = () => (
+  <SmallButton>
+    <span aria-label="pencil" role="img">✏️</span>
+    필기도구
+  </SmallButton>
+);
+
+
+export default NoteButton;

--- a/web/src/components/channel/Slide/SlideStatus/NoteButton/index.js
+++ b/web/src/components/channel/Slide/SlideStatus/NoteButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './NoteButton';

--- a/web/src/components/channel/Slide/SlideStatus/SlideStatus.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/SlideStatus.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+import StatusButton from './StatusButton';
+import SlideSyncButton from './SlideSyncButton';
+import NoteButton from './NoteButton';
+import FullScreenButton from './FullScreenButton';
+import { useChannelSelector } from '@/hooks';
+
+
+const SlideStatus = (props) => {
+  const { isSync, handleSync } = props;
+  const isMaster = useChannelSelector((state) => state.isMaster);
+
+  return (
+    <S.SlideStatus>
+      <StatusButton />
+      <S.Wrapper>
+        {!isMaster
+        && (
+        <SlideSyncButton
+          isSync={isSync}
+          handleSync={handleSync}
+        />
+        )}
+        <NoteButton />
+        <FullScreenButton />
+      </S.Wrapper>
+    </S.SlideStatus>
+  );
+};
+
+SlideStatus.propTypes = {
+  isSync: PropTypes.bool.isRequired,
+  handleSync: PropTypes.func.isRequired,
+};
+
+export default SlideStatus;

--- a/web/src/components/channel/Slide/SlideStatus/SlideSyncButton/SlideSyncButton.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/SlideSyncButton/SlideSyncButton.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { SmallButton } from '@/components/common';
+
+const SlideSyncButton = (props) => {
+  const { isSync, handleSync } = props;
+  const color = isSync ? 'secondary' : 'inherit';
+
+  return (
+    <SmallButton
+      color={color}
+      onClick={handleSync(!isSync)}
+    >
+      <span aria-label="sync" role="img">⚡️</span>
+      스피커 동기화
+    </SmallButton>
+  );
+};
+
+SlideSyncButton.propTypes = {
+  isSync: PropTypes.bool.isRequired,
+  handleSync: PropTypes.func.isRequired,
+};
+
+export default SlideSyncButton;

--- a/web/src/components/channel/Slide/SlideStatus/SlideSyncButton/index.js
+++ b/web/src/components/channel/Slide/SlideStatus/SlideSyncButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlideSyncButton';

--- a/web/src/components/channel/Slide/SlideStatus/StatusButton/StatusButton.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/StatusButton/StatusButton.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { SmallButton } from '@/components/common';
+
+const StatusButton = () => (
+  <SmallButton color="primary">
+    <span aria-label="sync" role="img">🐥</span>
+    presentation-on
+  </SmallButton>
+);
+
+
+export default StatusButton;

--- a/web/src/components/channel/Slide/SlideStatus/StatusButton/index.js
+++ b/web/src/components/channel/Slide/SlideStatus/StatusButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './StatusButton';

--- a/web/src/components/channel/Slide/SlideStatus/index.js
+++ b/web/src/components/channel/Slide/SlideStatus/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlideStatus';

--- a/web/src/components/channel/Slide/SlideStatus/style.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/style.jsx
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+import { colorGray, px } from '@/styles/themeUtil';
+
+export default {
+  SlideStatus: styled.div`
+    height: ${px(76)};
+    width: 94%;
+    border-bottom: 1px solid ${colorGray(3)};
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  `,
+  Wrapper: styled.div`
+   button{
+      margin-left:10px;
+   }
+  `,
+};

--- a/web/src/components/channel/Slide/SlideViewer/Indicator/Indicator.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/Indicator/Indicator.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+
+const Indicator = (props) => {
+  const { direction, handleSetPage } = props;
+
+  return (
+    <S.Indicator
+      onClick={handleSetPage(direction)}
+      direction={direction}
+    >
+      <S.ArrowWrapper direction={direction}>
+        {direction === 'back'
+          ? <S.ArrowBack />
+          : <S.ArrowFoward />}
+      </S.ArrowWrapper>
+    </S.Indicator>
+  );
+};
+
+Indicator.propTypes = {
+  direction: PropTypes.string.isRequired,
+  handleSetPage: PropTypes.func.isRequired,
+
+};
+
+export default Indicator;

--- a/web/src/components/channel/Slide/SlideViewer/Indicator/index.js
+++ b/web/src/components/channel/Slide/SlideViewer/Indicator/index.js
@@ -1,0 +1,1 @@
+export { default } from './Indicator';

--- a/web/src/components/channel/Slide/SlideViewer/Indicator/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/Indicator/style.jsx
@@ -1,0 +1,45 @@
+import styled from 'styled-components';
+import { ArrowBackIosRounded, ArrowForwardIosRounded } from '@material-ui/icons';
+import { px, colorGray } from '@/styles/themeUtil';
+
+export default {
+  Indicator: styled.div`
+    height: 100%;
+    min-width: ${px(80)};
+    width: 20%;
+    position: absolute;
+    top: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    cursor: pointer;
+    ${(props) => (props.direction === 'back'
+    ? 'left: 0'
+    : 'right: 0')};
+    &:hover{
+      div{
+        opacity: 1;
+      }
+    }
+  `,
+  ArrowWrapper: styled.div`
+    height: ${px(40)};
+    width: ${px(40)};
+    align-self: ${(props) => (props.direction === 'back'
+    ? 'flex-start'
+    : 'flex-end')};
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    opacity: 0;
+    transition: opacity 0.2s;
+  `,
+  ArrowBack: styled(ArrowBackIosRounded)`
+    color: ${colorGray(5)};
+    transform: scale(1.5);
+  `,
+  ArrowFoward: styled(ArrowForwardIosRounded)`
+    color: ${colorGray(5)};
+    transform: scale(1.5);
+  `,
+};

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+
+const MainSlide = (props) => {
+  const { page, slideUrls } = props;
+
+  return (
+    <S.MainSlide>
+      <S.SlideImg alt="slide" src={slideUrls[page]} />
+    </S.MainSlide>
+  );
+};
+
+MainSlide.propTypes = {
+  page: PropTypes.number.isRequired,
+  slideUrls: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default MainSlide;

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/index.js
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainSlide';

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/style.jsx
@@ -1,0 +1,24 @@
+import styled from 'styled-components';
+import { px } from '@/styles/themeUtil';
+
+export default {
+  MainSlide: styled.div`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    height: 100%;
+    padding: ${px(40)} 0;
+  `,
+  SlideImg: styled.img`
+    user-select: none;
+    height:auto;
+    width:auto;
+    max-width: 100%;
+    border-radius: ${px(3)};
+    max-height: 100%;
+    object-fit: contain;
+    background-color: ${({ theme }) => theme.palette.common.white};
+    box-shadow: ${({ theme }) => theme.palette.shadow.slide};
+  `,
+};

--- a/web/src/components/channel/Slide/SlideViewer/PageNumber/PageNumber.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/PageNumber/PageNumber.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+
+const PageNumber = (props) => {
+  const { slideLength, currentSlide } = props;
+
+  return (
+    <S.PageNumber>
+      {currentSlide}
+/
+      {slideLength}
+    </S.PageNumber>
+  );
+};
+
+PageNumber.propTypes = {
+  slideLength: PropTypes.number.isRequired,
+  currentSlide: PropTypes.number.isRequired,
+
+};
+
+export default PageNumber;

--- a/web/src/components/channel/Slide/SlideViewer/PageNumber/index.js
+++ b/web/src/components/channel/Slide/SlideViewer/PageNumber/index.js
@@ -1,0 +1,1 @@
+export { default } from './PageNumber';

--- a/web/src/components/channel/Slide/SlideViewer/PageNumber/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/PageNumber/style.jsx
@@ -1,0 +1,14 @@
+import styled from 'styled-components';
+import { colorGray, px } from '@/styles/themeUtil';
+
+export default {
+  PageNumber: styled.div`
+    font-size: ${px(14)};
+    color: ${colorGray(6)};
+    position: absolute;
+    bottom: ${px(10)};
+    left: 50%;
+    transform: translateX(-50%);
+    user-select: none;
+  `,
+};

--- a/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
@@ -1,0 +1,76 @@
+import React, { useEffect } from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+import {
+  useChannelSelector,
+  useSetCurrentSlide,
+  useSlideChanged,
+  useSyncSlide,
+} from '@/hooks';
+import { moveSlide, moveSlidePossible } from '@/utils/slide';
+import Indicator from './Indicator';
+import MainSlide from './MainSlide';
+import PageNumber from './PageNumber';
+
+const SlideViewer = (props) => {
+  const {
+    channelId,
+    isSync,
+    setSync,
+    page,
+    setPage,
+  } = props;
+  const { mutate } = useSetCurrentSlide();
+  const { currentSlide } = useSlideChanged(channelId);
+  const { slideUrls, isMaster } = useChannelSelector((state) => state);
+  const syncSlide = useSyncSlide(
+    isMaster,
+    isSync,
+    page,
+    currentSlide,
+  );
+  const handleSetPage = (direction) => () => {
+    const sync = isSync ? currentSlide : page;
+    if (!moveSlidePossible(direction, sync, slideUrls.length)) return;
+    if (!isMaster && isSync) {
+      setSync(false);
+      moveSlide(direction, setPage, currentSlide);
+      return;
+    } moveSlide(direction, setPage, page);
+  };
+
+  useEffect(() => {
+    if (!isMaster) return;
+    mutate({ variables: { channelId, currentSlide: page } });
+  }, [page]);
+
+  return (
+    <S.SlideViewer>
+      <MainSlide
+        page={syncSlide}
+        slideUrls={slideUrls}
+      />
+      {['back', 'foward'].map((direction) => (
+        <Indicator
+          key={direction}
+          direction={direction}
+          handleSetPage={handleSetPage}
+        />
+      ))}
+      <PageNumber
+        currentSlide={syncSlide + 1}
+        slideLength={slideUrls.length}
+      />
+    </S.SlideViewer>
+  );
+};
+
+SlideViewer.propTypes = {
+  channelId: PropTypes.string.isRequired,
+  isSync: PropTypes.bool.isRequired,
+  setSync: PropTypes.func.isRequired,
+  page: PropTypes.number.isRequired,
+  setPage: PropTypes.func.isRequired,
+};
+
+export default SlideViewer;

--- a/web/src/components/channel/Slide/SlideViewer/index.js
+++ b/web/src/components/channel/Slide/SlideViewer/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlideViewer';

--- a/web/src/components/channel/Slide/SlideViewer/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/style.jsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export default {
+  SlideViewer: styled.div`
+    flex: 1;
+    width: 94%;
+    height: 100%;
+    position: relative;
+  `,
+};

--- a/web/src/components/channel/Slide/index.js
+++ b/web/src/components/channel/Slide/index.js
@@ -1,0 +1,1 @@
+export { default } from './Slide';

--- a/web/src/components/channel/Slide/style.jsx
+++ b/web/src/components/channel/Slide/style.jsx
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export default {
+  Slide: styled.div`
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    height: 100%;
+  `,
+};

--- a/web/src/components/channel/ToolBar/ToolBar.jsx
+++ b/web/src/components/channel/ToolBar/ToolBar.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import S from './style';
+
+const style = () => (
+  <S.ToolBar></S.ToolBar>
+);
+
+export default style;

--- a/web/src/components/channel/ToolBar/index.js
+++ b/web/src/components/channel/ToolBar/index.js
@@ -1,0 +1,1 @@
+export { default } from './ToolBar';

--- a/web/src/components/channel/ToolBar/style.jsx
+++ b/web/src/components/channel/ToolBar/style.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+import { colorGray } from '@/styles/themeUtil';
+
+export default {
+  ToolBar: styled.div`
+    width:60px;
+    height:100%;
+    background: ${colorGray(0)};
+    border-right: 1px solid ${colorGray(2)};
+  `,
+};

--- a/web/src/hooks/channel/slide/index.js
+++ b/web/src/hooks/channel/slide/index.js
@@ -1,0 +1,3 @@
+export { default as useSetCurrentSlide } from './useSetCurrentSlide';
+export { default as useSlideChanged } from './useSlideChanged';
+export { default as useSyncSlide } from './useSyncSlide';

--- a/web/src/hooks/channel/slide/useSetCurrentSlide.js
+++ b/web/src/hooks/channel/slide/useSetCurrentSlide.js
@@ -1,0 +1,17 @@
+import gql from 'graphql-tag';
+import { useMutation } from '@apollo/react-hooks';
+
+const SET_CURRENT_SLIDE = gql`
+  mutation SetCurrentSlide($channelId: String!, $currentSlide: Int!) {
+    setCurrentSlide(channelId: $channelId, currentSlide: $currentSlide) { 
+     currentSlide
+    }
+  }
+`;
+
+const useSetCurrentSlide = () => {
+  const [setCurrentSlide] = useMutation(SET_CURRENT_SLIDE);
+  return { mutate: setCurrentSlide };
+};
+
+export default useSetCurrentSlide;

--- a/web/src/hooks/channel/slide/useSlideChanged.js
+++ b/web/src/hooks/channel/slide/useSlideChanged.js
@@ -1,0 +1,22 @@
+import gql from 'graphql-tag';
+import { useSubscription } from '@apollo/react-hooks';
+import { useChannelSelector } from '@/hooks';
+
+const SLIDE_CHANGED = gql`
+  subscription SlideChanged($channelId: String!) {
+    slideChanged(channelId: $channelId) {
+      currentSlide
+    }
+  }
+`;
+
+const useSlideChanged = (channelId) => {
+  const initialSlide = useChannelSelector((state) => state.initialSlide);
+  const { data } = useSubscription(SLIDE_CHANGED, { variables: { channelId } });
+  const currentSlide = !data ? initialSlide : data.slideChanged.currentSlide;
+
+  return { currentSlide };
+};
+
+
+export default useSlideChanged;

--- a/web/src/hooks/channel/slide/useSyncSlide.js
+++ b/web/src/hooks/channel/slide/useSyncSlide.js
@@ -1,0 +1,12 @@
+const useSyncSlide = (
+  isMaster,
+  isSync,
+  page,
+  currentSlide,
+) => {
+  if (isMaster) return page;
+  if (!isMaster && isSync) return currentSlide;
+  return page;
+};
+
+export default useSyncSlide;

--- a/web/src/hooks/channel/useChannelSelector.js
+++ b/web/src/hooks/channel/useChannelSelector.js
@@ -1,0 +1,9 @@
+import { useContext } from 'react';
+import { ChannelContext } from '@/contexts';
+
+const useChannelSelector = (selector) => {
+  const state = useContext(ChannelContext);
+  return selector(state);
+};
+
+export default useChannelSelector;

--- a/web/src/hooks/channel/useCreateChannel.js
+++ b/web/src/hooks/channel/useCreateChannel.js
@@ -1,0 +1,34 @@
+import gql from 'graphql-tag';
+import { useMutation } from '@apollo/react-hooks';
+
+const CREATE_CHANNEL = gql`
+  mutation createChannel(
+    $channelId: String!, 
+    $channelCode: String!,
+    $slideUrls: [String], 
+    $fileUrl: String,
+  ) {
+    createChannel(
+      channelId: $channelId,
+      channelCode: $channelCode,
+      slideUrls: $slideUrls,
+      fileUrl: $fileUrl
+    ) { 
+      status 
+      channel { 
+        channelId
+      }
+    }
+  }
+`;
+
+const useCreateChannel = () => {
+  const [createChannel, result] = useMutation(CREATE_CHANNEL);
+  const data = result.data
+    ? result.data.createChannel
+    : { status: null, channel: { channelId: null } };
+
+  return { mutate: createChannel, data };
+};
+
+export default useCreateChannel;

--- a/web/src/hooks/channel/useGetChannel.js
+++ b/web/src/hooks/channel/useGetChannel.js
@@ -1,0 +1,29 @@
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+const CHECK_CHANNEL = gql`
+  query GetChannel($channelId: String!) {
+    getChannel(channelId: $channelId) {
+      status
+      isMaster
+      channel{
+        slideUrls
+        fileUrl
+        master{
+          displayName
+        }
+        channelName
+        currentSlide
+      }
+    }
+  } 
+`;
+
+const useGetChannel = (channelId) => {
+  const result = useQuery(CHECK_CHANNEL, { variables: { channelId } });
+  const data = result.data ? result.data.getChannel : null;
+
+  return { data };
+};
+
+export default useGetChannel;

--- a/web/src/styles/theme.js
+++ b/web/src/styles/theme.js
@@ -1,0 +1,129 @@
+import { createMuiTheme } from '@material-ui/core/styles';
+
+export default createMuiTheme({
+  palette: {
+    default: '#f8f9fa',
+    common: {
+      white: '#ffffff',
+      black: '#000',
+    },
+    primary: {
+      contrastText: '#fff',
+      main: '#e67700',
+      light: '#FAB005',
+    },
+    secondary: {
+      contrastText: '#fff',
+      main: '#dee2e6',
+      light: '#343a40',
+    },
+    background: {
+      light: '#fff9db',
+      main: '#F1F3F5',
+    },
+    naver: '#2db400',
+    kakao: '#fee102',
+    google: '#fff',
+    dropyGray: {
+      0: '#f8f9fa',
+      1: '#f1f3f5',
+      2: '#e9ecef',
+      3: '#dee2e6',
+      4: '#ced4da',
+      5: '#adb5bd',
+      6: '#868e96',
+      7: '#495057',
+      8: '#343a40',
+      9: '#212529',
+    },
+    dropyYellow: {
+      0: '#fff9db',
+      1: '#fff3bf',
+      2: '#ffec99',
+      3: '#ffe066',
+      4: '#ffd43b',
+      5: '#fcc419',
+      6: '#fab005',
+      7: '#f59f00',
+      8: '#f08c00',
+      9: '#e67700',
+    },
+    shadow: {
+      button: 'rgba(0, 0, 0, 0.24) 0px 2px 2px 0px, rgba(0, 0, 0, 0.24) 0px 0px 1px 0px',
+      channelButton: '0px 2px 19px rgba(230, 119, 0, 0.4)',
+      slide: '10px 2px 20px rgba(0, 0, 0, 0.1)',
+    },
+  },
+  typography: {
+    pxToRem: (value) => `${value / 16}rem`,
+    fontFamily: [
+      'Spoqa Han Sans', 'Spoqa Han Sans JP', 'Sans-serif',
+    ].join(','),
+    h1: {
+      color: '#e67700',
+      fontSize: '1.3rem',
+      fontWeight: 700,
+    },
+  },
+  overrides: {
+    MuiAppBar: {
+      root: {
+        position: 'relative',
+        height: '50px',
+      },
+      colorPrimary: {
+        'background-color': '#f8f9fa',
+        'border-bottom': '1px solid #dee2e6',
+        flex: 0,
+      },
+    },
+    MuiToolbar: {
+      root: {
+        height: '50px',
+      },
+      regular: {
+        'min-height': '50px !important',
+      },
+    },
+    MuiButton: {
+      contained: {
+        'background-color': '#FFFFFF',
+        'box-shadow': '0px 2px 9px rgba(0, 0, 0, 0.03)',
+        'border-radius': '3px',
+        padding: '4px 10px',
+        '&:hover': {
+          'background-color': '#f8f9fa',
+          'box-shadow': '0px 2px 6px rgba(0, 0, 0, 0.2)',
+        },
+      },
+      containedPrimary: {
+        'background-color': '#e67700',
+        'box-shadow': '0px 2px 9px rgba(0, 0, 0, 0.03)',
+        '&:hover': {
+          'background-color': '#e67700',
+          'box-shadow': '0px 2px 9px rgba(0, 0, 0, 0.03)',
+        },
+      },
+      containedSecondary: {
+        'background-color': '#ADB5BD',
+        '&:hover': {
+          'background-color': '#868E96',
+        },
+      },
+    },
+    MuiSwitch: {
+      colorPrimary: {
+        color: '#f8f9fa !important',
+      },
+      switchBase: {
+        '&$checked': {
+          transform: 'translateX(60%)',
+        },
+      },
+      track: {
+        'background-color': '#868e96',
+        opacity: '1 !important',
+      },
+    },
+  },
+});

--- a/web/src/styles/themeUtil.js
+++ b/web/src/styles/themeUtil.js
@@ -1,0 +1,13 @@
+const px = (val) => ({ theme }) => theme.typography.pxToRem(val);
+const colorGray = (val) => ({ theme }) => theme.palette.dropyGray[val];
+const colorYellow = (val) => ({ theme }) => theme.palette.dropyYellow[val];
+const colorPrimary = (val) => ({ theme }) => theme.palette.primary[val];
+const colorCommon = (val) => ({ theme }) => theme.palette.common[val];
+
+export {
+  px,
+  colorGray,
+  colorYellow,
+  colorPrimary,
+  colorCommon,
+};

--- a/web/src/utils/slide.js
+++ b/web/src/utils/slide.js
@@ -1,0 +1,9 @@
+const moveSlidePossible = (direction, current, length) => (!((direction === 'back' && current === 0)
+|| (direction === 'foward' && current === length - 1)));
+
+const moveSlide = (direction, cb, page) => {
+  if (direction === 'back') cb(page - 1);
+  else cb(page + 1);
+};
+
+export { moveSlide, moveSlidePossible };


### PR DESCRIPTION
# [조애리]w4_리뷰요청_슬라이드_컴포넌트_구현

## 해당 이슈 📎
- [Epic#14, Epic#35] 슬라이드를 앞뒤로 넘길 수 있다. (#42 )
- [Epic#32] 스피커의 화면을 동기화하여 볼 수 있다.(#47 ) 
- [Epic#14, Epic#35] 슬라이드 UI 보완 (#66 )

## 개발상황 요약 📝
- 채널 접속 시 보이는 슬라이드 부분을 구현하였습니다.
<img width="455" alt="channel" src="https://user-images.githubusercontent.com/29801123/69838735-3151e100-1298-11ea-91dc-330dfc06f13a.png"> 
  
- server-converter에서 오브젝트 스토리지에 파일 업로드 후 url을 응답하도록 수정하였습니다.
- 클라이언트에서 응답을 받아 api서버에서 디비에 저장합니다.
- channel 관련 graphQL reslover에서 해당 데이터를 내려줍니다.
- react contextAPI를 통해 채널 페이지에서 전역으로 데이터를 내려줍니다.
- graphQL subscription을 통해 슬라이드 페이지를 스피커와 동기화하는 로직을 구현했습니다.


## 리뷰어님 참고 사항 🙋‍♀️
- 슬라이드 기능 관련하여 작업한 부분만 업로드하였습니다!

## 리뷰어님께 드리고 싶은 질문 ❓

1. 채널 데이터를 context api를 이용하여 페이지에서 내려주고 있는데요, 데이터는 전역으로 관리할 경우, 실제 이벤트가 발생하는 하위 컴포넌트에서 상태변경을 처리하는 것이 좋은가요? 
(지금은 slideViewer같은 상위 컴포넌트에서 상태관리 로직을 props로 내려주고 있습니다)
2. 렌더링 최적화를 하고 싶은데 콘솔찍기밖에 시도해보지 못해서.. 현업에서는 어떻게 디버깅 하고 최적화하는지 궁금합니다~!