### PR TITLE
스피커, 리스너의 히스토리카드로 채널 입장 가능

### DIFF
--- a/server-api/src/apollo/resolvers/channels.js
+++ b/server-api/src/apollo/resolvers/channels.js
@@ -4,7 +4,6 @@ const Histories = require('../../models/histories');
 const Users = require('../../models/users');
 
 const SLIDE_CHANGED = 'SLIDE_CHANGED';
-const updatedAt = Date.now();
 
 const createChannelInfo = (
   user,
@@ -39,6 +38,7 @@ const createChannel = async (_, {
 
   const { userId } = user;
   const masterId = userId;
+  const updatedAt = Date.now();
   const newHistory = new Histories({
     userId,
     masterId,
@@ -61,22 +61,9 @@ const createChannel = async (_, {
 const getChannel = async (_, { channelId }, { user }) => {
   try {
     const channel = await Channels.findOne({ channelId });
-    const { userId } = user;
-    const { masterId } = channel;
     const master = await Users.findOne({ userId: channel.masterId });
     const status = channel ? 'ok' : 'not_exist';
     const isMaster = !!channel && !!user && channel.masterId === user.userId;
-    const findHistory = await Histories.find({ userId, channelId });
-    const firstVisitedChannel = () => !isMaster && findHistory.length === 0;
-    if (firstVisitedChannel()) {
-      const newHistory = new Histories({
-        userId,
-        masterId,
-        channelId,
-        updatedAt,
-      });
-      await newHistory.save();
-    }
     if (!channel) return { status, isMaster };
 
     const payload = await channel.toPayload({ master });

--- a/server-api/src/apollo/resolvers/channels.js
+++ b/server-api/src/apollo/resolvers/channels.js
@@ -66,7 +66,9 @@ const getChannel = async (_, { channelId }, { user }) => {
     const master = await Users.findOne({ userId: channel.masterId });
     const status = channel ? 'ok' : 'not_exist';
     const isMaster = !!channel && !!user && channel.masterId === user.userId;
-    if (!isMaster) {
+    const findHistory = await Histories.find({ userId, channelId });
+    const firstVisitedChannel = () => !isMaster && findHistory.length === 0;
+    if (firstVisitedChannel()) {
       const newHistory = new Histories({
         userId,
         masterId,

--- a/server-api/src/apollo/resolvers/histories.js
+++ b/server-api/src/apollo/resolvers/histories.js
@@ -1,5 +1,37 @@
 const { ApolloError } = require('apollo-server-express');
+const Channels = require('../../models/channels');
 const Histories = require('../../models/histories');
+
+
+const addHistory = async (_, {
+  channelId,
+}, { user }) => {
+  const channel = await Channels.findOne({ channelId });
+  const { masterId } = channel;
+  const { userId } = user;
+  const updatedAt = Date.now();
+  const findHistory = await Histories.find({ userId, channelId });
+  const isMaster = masterId === userId;
+  const firstVisitedChannel = () => !isMaster && findHistory.length === 0;
+
+  if (!firstVisitedChannel()) return { status: 'not_exist', history: null };
+
+  const newHistory = new Histories({
+    userId,
+    masterId,
+    channelId,
+    updatedAt,
+  });
+
+  try {
+    const history = await newHistory.save();
+    const payload = await history.toPayload();
+
+    return { status: 'ok', history: payload };
+  } catch (err) {
+    throw new ApolloError(err.message);
+  }
+};
 
 const getHistories = async (_, __, { user }) => {
   try {
@@ -15,6 +47,9 @@ const getHistories = async (_, __, { user }) => {
 const resolvers = {
   Query: {
     getHistories,
+  },
+  Mutation: {
+    addHistory,
   },
 };
 

--- a/server-api/src/apollo/typeDefs/histories.js
+++ b/server-api/src/apollo/typeDefs/histories.js
@@ -4,6 +4,15 @@ type History {
   updatedAt: Date
 }
 
+type AddHistoryResponse {
+  status: String!
+  history: History
+}
+
+extend type Mutation {
+  addHistory(channelId: String!): AddHistoryResponse
+}
+
 extend type Query {
   getHistories: [History]
 }

--- a/server-api/src/models/histories.js
+++ b/server-api/src/models/histories.js
@@ -56,7 +56,6 @@ HistorySchema.methods.toPayload = async function toHistoryPayload() {
   const history = this;
   const { channelId, updatedAt } = history;
   const channel = await Channels.findOne({ channelId });
-  console.log(channel);
   const channelPayload = channel ? channel.toPayload() : {
     master: {},
     slideUrls: [],

--- a/web/src/components/common/Header/LogoutPopover/LogoutPopover.jsx
+++ b/web/src/components/common/Header/LogoutPopover/LogoutPopover.jsx
@@ -16,7 +16,7 @@ const LogoutPopover = (props) => {
   return (
     <S.PopoverWrapper>
       <Link to="/mypage">
-        <MenuItem>프로필</MenuItem>
+        <MenuItem onClick={handleClose}>프로필</MenuItem>
       </Link>
       <MenuItem onClick={handleLogOut}>
         로그아웃

--- a/web/src/components/common/Header/LogoutPopover/LogoutPopover.jsx
+++ b/web/src/components/common/Header/LogoutPopover/LogoutPopover.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { MenuItem } from '@material-ui/core';
-import { Redirect } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useLogout } from '@/hooks';
 import S from './style';
 
@@ -12,13 +12,12 @@ const LogoutPopover = (props) => {
     handleClose();
     logOut();
   };
-  const setMyPage = () => <Redirect to="/mypage" />;
 
   return (
     <S.PopoverWrapper>
-      <MenuItem onClick={setMyPage}>
-        프로필
-      </MenuItem>
+      <Link to="/mypage">
+        <MenuItem>프로필</MenuItem>
+      </Link>
       <MenuItem onClick={handleLogOut}>
         로그아웃
       </MenuItem>

--- a/web/src/components/history/UserHistory/UserHistory.jsx
+++ b/web/src/components/history/UserHistory/UserHistory.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import UserHistoryCard from '../UserHistoryCard';
 import { useGetUserHistories, useGetUserStatus } from '@/hooks';
+import dateParser from '@/utils/date';
 import S from './style';
 
 const UserHistory = (props) => {
@@ -16,13 +17,14 @@ const UserHistory = (props) => {
     : master.userId !== userId);
   const mapToCardComponent = (historyInfo) => {
     const { channel, updatedAt } = historyInfo;
+    const updatedDate = dateParser(updatedAt);
 
     return (
       <UserHistoryCard
         key={channel.channelId}
         channelId={channel.channelId}
         channelStatus={channel.channelStatus}
-        updatedAt={updatedAt}
+        updatedAt={updatedDate}
         channelName={channel.channelName}
         displayName={channel.master.displayName}
       />

--- a/web/src/components/history/UserHistory/UserHistory.jsx
+++ b/web/src/components/history/UserHistory/UserHistory.jsx
@@ -14,16 +14,20 @@ const UserHistory = (props) => {
   const filterToDomain = ({ channel: { master } }) => (historyState === 'speaker'
     ? master.userId === userId
     : master.userId !== userId);
-  const mapToCardComponent = (historyInfo) => (
-    <UserHistoryCard
-      key={historyInfo.channel.channelId}
-      channelId={historyInfo.channel.channelId}
-      channelStatus={historyInfo.channel.channelStatus}
-      updatedAt={historyInfo.updatedAt}
-      channelName={historyInfo.channel.channelName}
-      displayName={historyInfo.channel.master.displayName}
-    />
-  );
+  const mapToCardComponent = (historyInfo) => {
+    const { channel, updatedAt } = historyInfo;
+
+    return (
+      <UserHistoryCard
+        key={channel.channelId}
+        channelId={channel.channelId}
+        channelStatus={channel.channelStatus}
+        updatedAt={updatedAt}
+        channelName={channel.channelName}
+        displayName={channel.master.displayName}
+      />
+    );
+  };
   const historyCardList = data && data.length > 0
     ? data.filter(filterToDomain).map(mapToCardComponent)
     : <p>아직 채널을 한번도 생성 안해보셨네요??</p>;

--- a/web/src/components/history/UserHistory/UserHistory.jsx
+++ b/web/src/components/history/UserHistory/UserHistory.jsx
@@ -17,6 +17,7 @@ const UserHistory = (props) => {
   const mapToCardComponent = (historyInfo) => (
     <UserHistoryCard
       key={historyInfo.channel.channelId}
+      channelId={historyInfo.channel.channelId}
       channelStatus={historyInfo.channel.channelStatus}
       updatedAt={historyInfo.updatedAt}
       channelName={historyInfo.channel.channelName}

--- a/web/src/components/history/UserHistory/style.jsx
+++ b/web/src/components/history/UserHistory/style.jsx
@@ -16,6 +16,7 @@ export default {
   UserHistoryContents: styled.div`
     position: absolute;
     width: 100%;
+    padding-top: ${px(50)};
   `,
   UserHistoryTitle: styled(Card)`
     margin: ${px(20)} ${px(100)};

--- a/web/src/components/history/UserHistoryCard/UserHistoryCard.jsx
+++ b/web/src/components/history/UserHistoryCard/UserHistoryCard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import { Typography, Chip } from '@material-ui/core';
-import FaceIcon from '@material-ui/icons/Face';
+import { Typography } from '@material-ui/core';
+import { SmallButton } from '@/components/common';
 import S from './style';
 
 const UserHistoryCard = (props) => {
@@ -13,8 +13,9 @@ const UserHistoryCard = (props) => {
     channelName,
     displayName,
   } = props;
-  const label = channelStatus === 'on' ? '현재 생방송중!' : '종료된 채널';
-  const color = channelStatus === 'on' ? 'primary' : 'default';
+  const presentationStatus = channelStatus === 'on'
+    ? { label: 'presentation-on', color: 'primary' }
+    : { label: 'presentation-off', color: 'default' };
 
   return (
     <>
@@ -30,12 +31,10 @@ const UserHistoryCard = (props) => {
           </S.HistoryCardLeftDetail>
           <S.HistoryCardRightDetail>
             <Typography variant="subtitle1">
-              <Chip
-                icon={<FaceIcon />}
-                label={label}
-                color={color}
-                variant="outlined"
-              />
+              <SmallButton color={presentationStatus.color}>
+                <span aria-label="sync" role="img">🐥</span>
+                {presentationStatus.label}
+              </SmallButton>
             </Typography>
             <Typography component="h6" variant="h6">
               {displayName}

--- a/web/src/components/history/UserHistoryCard/UserHistoryCard.jsx
+++ b/web/src/components/history/UserHistoryCard/UserHistoryCard.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
-import Typography from '@material-ui/core/Typography';
-import Chip from '@material-ui/core/Chip';
+import { Typography, Chip } from '@material-ui/core';
 import FaceIcon from '@material-ui/icons/Face';
 import S from './style';
 
 const UserHistoryCard = (props) => {
   const {
+    channelId,
     channelStatus,
     updatedAt,
     channelName,
@@ -17,37 +18,40 @@ const UserHistoryCard = (props) => {
 
   return (
     <>
-      <S.HistoryCard>
-        <S.HistoryCardLeftDetail>
-          <Typography variant="subtitle1" color="textSecondary">
-            {updatedAt}
-          </Typography>
-          <Typography component="h5" variant="h5">
-            {channelName}
-          </Typography>
-        </S.HistoryCardLeftDetail>
-        <S.HistoryCardRightDetail>
-          <Typography variant="subtitle1">
-            <Chip
-              icon={<FaceIcon />}
-              label={label}
-              color={color}
-              variant="outlined"
-            />
-          </Typography>
-          <Typography component="h6" variant="h6">
-            {displayName}
-          </Typography>
-        </S.HistoryCardRightDetail>
-        <S.HistoryCardMiddleDetail>
-          <S.Profile />
-        </S.HistoryCardMiddleDetail>
-      </S.HistoryCard>
+      <Link to={`/channels/${channelId}`}>
+        <S.HistoryCard>
+          <S.HistoryCardLeftDetail>
+            <Typography variant="subtitle1" color="textSecondary">
+              {updatedAt}
+            </Typography>
+            <Typography component="h5" variant="h5">
+              {channelName}
+            </Typography>
+          </S.HistoryCardLeftDetail>
+          <S.HistoryCardRightDetail>
+            <Typography variant="subtitle1">
+              <Chip
+                icon={<FaceIcon />}
+                label={label}
+                color={color}
+                variant="outlined"
+              />
+            </Typography>
+            <Typography component="h6" variant="h6">
+              {displayName}
+            </Typography>
+          </S.HistoryCardRightDetail>
+          <S.HistoryCardMiddleDetail>
+            <S.Profile />
+          </S.HistoryCardMiddleDetail>
+        </S.HistoryCard>
+      </Link>
     </>
   );
 };
 
 UserHistoryCard.propTypes = {
+  channelId: PropTypes.string.isRequired,
   channelStatus: PropTypes.string.isRequired,
   updatedAt: PropTypes.number.isRequired,
   channelName: PropTypes.string.isRequired,

--- a/web/src/components/history/UserHistoryCard/style.jsx
+++ b/web/src/components/history/UserHistoryCard/style.jsx
@@ -5,6 +5,7 @@ import { px, colorGray } from '@/styles';
 
 export default {
   HistoryCard: styled(Card)`
+    cursor: pointer;
     margin: ${px(50)} ${px(100)};
     min-width: ${px(700)};
     &:first-of-type {

--- a/web/src/components/history/UserHistoryCard/style.jsx
+++ b/web/src/components/history/UserHistoryCard/style.jsx
@@ -8,9 +8,6 @@ export default {
     cursor: pointer;
     margin: ${px(50)} ${px(100)};
     min-width: ${px(700)};
-    &:first-of-type {
-      margin-top: ${px(100)};
-    }
   `,
   HistoryCardLeftDetail: styled.div`
     margin: ${px(50)} 0 ${px(50)} ${px(50)};
@@ -23,9 +20,6 @@ export default {
   HistoryCardRightDetail: styled.div`
     margin: ${px(50)} ${px(50)} ${px(50)} 0;
     float: right;
-  `,
-  OnAir: styled.div`
-    width: ${px(200)};
   `,
   Profile: styled.div`
     width: ${px(80)};

--- a/web/src/hooks/history/useAddUserHistory.js
+++ b/web/src/hooks/history/useAddUserHistory.js
@@ -2,14 +2,29 @@ import gql from 'graphql-tag';
 import { useMutation } from '@apollo/react-hooks';
 
 const ADD_HISTORY = gql`
-  mutation AddHistory($userId: String!, $masterId: String!, $channelName: String!, $channelId: String!, $channelStatus: String!, $updatedAt: Date!) {
-    addHistory(userId: $userId, masterId: $masterId, channelName: $channelName, channelId: $channelId, channelStatus: $channelStatus, updatedAt: $updatedAt) @client
+  mutation addHistory(
+    $channelId: String!,
+  ) {
+    addHistory(
+      channelId: $channelId,
+    ) {
+      status
+      history {
+        channel {
+          channelId
+        }
+      }
+    }
   }
 `;
 
 const useAddUserHistory = () => {
-  const [addHistory] = useMutation(ADD_HISTORY);
-  return { mutate: addHistory };
+  const [addHistory, result] = useMutation(ADD_HISTORY);
+  const data = result.data
+    ? result.data.addHistory
+    : { status: null, history: { userId: null, channelId: null } };
+
+  return { mutate: addHistory, data };
 };
 
 export default useAddUserHistory;

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -6,6 +6,7 @@ import {
   useGetUserStatus,
   useGetChannel,
   useInitChatCached,
+  useAddUserHistory,
 } from '@/hooks';
 import { Chat, Slide, ToolBar } from '@/components/channel';
 import { authByAnonymous } from '@/apis';
@@ -16,6 +17,7 @@ const Channel = () => {
   const { data } = useGetChannel(channelId);
   const logIn = useLogin();
   const userStatus = useGetUserStatus();
+  const { mutate } = useAddUserHistory();
 
   useInitChatCached();
   useEffect(() => {
@@ -26,6 +28,16 @@ const Channel = () => {
       isAnonymous: true,
     }));
   }, [userStatus]);
+
+  useEffect(() => {
+    if (data && data.status === 'ok') {
+      mutate({
+        variables: {
+          channelId,
+        },
+      });
+    }
+  }, [data]);
 
   if (!data) return null;
   if (data.status === 'not_exist') {

--- a/web/src/utils/date.js
+++ b/web/src/utils/date.js
@@ -1,0 +1,6 @@
+const dateParser = (updatedAt) => {
+  const date = new Date(updatedAt);
+  return `${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일`;
+};
+
+export default dateParser;


### PR DESCRIPTION
# [Epic#8, Epic#10] 스피커, 리스너의 히스토리카드로 채널 입장 가능

## 해당 이슈 📎

-[Epic#8, Epic#10] 스피커, 리스너의 히스토리카드로 채널 입장 가능 (#44)

## 변경 사항 🛠

```javascript
const getChannel = async (_, { channelId }, { user }) => {
  try {
    const channel = await Channels.findOne({ channelId });
    const { userId } = user;
    const { masterId } = channel;
    const master = await Users.findOne({ userId: channel.masterId });
    const status = channel ? 'ok' : 'not_exist';
    const isMaster = !!channel && !!user && channel.masterId === user.userId;
    const findHistory = await Histories.find({ userId, channelId });
    const firstVisitedChannel = () => !isMaster && findHistory.length === 0;
    if (firstVisitedChannel()) {
      const newHistory = new Histories({
        userId,
        masterId,
        channelId,
        updatedAt,
      });
      await newHistory.save();
    }
    if (!channel) return { status, isMaster };

    const payload = await channel.toPayload({ master });

    return {
      status,
      isMaster,
      channel: payload,
    };
  } catch (err) {
    throw new ApolloError(err.message);
  }
};
```

- 채널의 정보를 가져올 때, 처음 방문인 채널인 경우 히스토리에 추가하도록 했습니다. 하지만 함수 단위가 커져서 고민입니다. 🤔 어떻게 생각하시는지 이 쪽을 중점적으로 리뷰를 부탁드립니다.
- 이제 라우팅 효과가 정상적으로 작동 됩니다.
- 히스토리가 정상적으로 쌓입니다.
- 카드 간격이 조금 더 자연스러워 졌습니다.

## 테스트 ✨

>없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음
