### PR TITLE
버튼 클릭 시, 채널 코드를 클립보드에 복사할 수 있도록 하는 CodeShareButton 컴포넌트 구현

### DIFF
--- a/web/src/components/channel/Slide/SlideInfo/CodeShareButton/CodeShareButton.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/CodeShareButton/CodeShareButton.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import { SmallButton } from '@/components/common';
 import { useChannelSelector } from '@/hooks';
+import { copyToClipboard } from '@/utils/dom';
 
 const CodeShareButton = () => {
   const channelCode = useChannelSelector((state) => state.channelCode);
   const handleCodeShareButtonOnClick = () => {
-    const element = document.createElement('textarea');
-    element.value = channelCode;
-    document.body.appendChild(element);
-    element.select();
-    document.execCommand('copy');
-    document.body.removeChild(element);
+    copyToClipboard(channelCode);
   };
 
   return (

--- a/web/src/components/channel/Slide/SlideInfo/CodeShareButton/CodeShareButton.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/CodeShareButton/CodeShareButton.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { SmallButton } from '@/components/common';
+import { useChannelSelector } from '@/hooks';
+
+const CodeShareButton = () => {
+  const channelCode = useChannelSelector((state) => state.channelCode);
+  const handleCodeShareButtonOnClick = () => {
+    const element = document.createElement('textarea');
+    element.value = channelCode;
+    document.body.appendChild(element);
+    element.select();
+    document.execCommand('copy');
+    document.body.removeChild(element);
+  };
+
+  return (
+    <SmallButton onClick={handleCodeShareButtonOnClick}>
+      <span aria-label="slide-code-share-button" role="img">📎</span>
+      <span>채널 공유</span>
+    </SmallButton>
+  );
+};
+
+export default CodeShareButton;

--- a/web/src/components/channel/Slide/SlideInfo/CodeShareButton/index.js
+++ b/web/src/components/channel/Slide/SlideInfo/CodeShareButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './CodeShareButton';

--- a/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import S from './style';
 import { useChannelSelector } from '@/hooks';
+import CodeShareButton from './CodeShareButton';
 
 const SlideInfo = () => {
   const channelName = useChannelSelector((state) => state.channelName);
@@ -15,6 +16,9 @@ const SlideInfo = () => {
           {masterName}
         </S.MasterName>
       </S.TitleWrapper>
+      <S.SlideButtonsWrapper>
+        <CodeShareButton />
+      </S.SlideButtonsWrapper>
     </S.SlideInfo>
   );
 };

--- a/web/src/components/channel/Slide/SlideInfo/style.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/style.jsx
@@ -6,7 +6,7 @@ export default {
     display: flex;
     flex-direction: row;
     height: ${px(142)};
-    width: 100%;
+    width: 94%;
     border-top: 1px solid ${colorGray(3)};
     padding: ${px(15)} 0 0 ${px(20)};
   `,
@@ -38,7 +38,6 @@ export default {
     display: flex;
     flex-direction: row-reverse;
     width: 50%;
-    margin-right: ${px(20)};
     button {
       margin-left: 10px;
    }

--- a/web/src/components/channel/Slide/SlideInfo/style.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/style.jsx
@@ -3,24 +3,44 @@ import { colorGray, px } from '@/styles/themeUtil';
 
 export default {
   SlideInfo: styled.div`
+    display: flex;
+    flex-direction: row;
     height: ${px(142)};
-    width:94%;
+    width: 100%;
     border-top: 1px solid ${colorGray(3)};
     padding: ${px(15)} 0 0 ${px(20)};
   `,
   TitleWrapper: styled.div`
     display: flex;
-    align-items:center;
+    width: 50%;
   `,
   ChannelTitle: styled.h1`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     font-size: ${px(24)};
     color: ${colorGray(7)};
     font-weight: 400;
     margin-right: ${px(20)};
+    align-items: center;
+    height: ${px(32)};
   `,
   MasterName: styled.h3`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
     font-size: ${px(18)};
     color: ${colorGray(7)};
     font-weight: 400;
+    height: ${px(32)};
+  `,
+  SlideButtonsWrapper: styled.div`
+    display: flex;
+    flex-direction: row-reverse;
+    width: 50%;
+    margin-right: ${px(20)};
+    button {
+      margin-left: 10px;
+   }
   `,
 };

--- a/web/src/components/channel/Slide/SlideStatus/style.jsx
+++ b/web/src/components/channel/Slide/SlideStatus/style.jsx
@@ -11,8 +11,8 @@ export default {
     justify-content: space-between;
   `,
   Wrapper: styled.div`
-   button{
-      margin-left:10px;
+   button {
+      margin-left: 10px;
    }
   `,
 };

--- a/web/src/components/common/SmallButton/style.jsx
+++ b/web/src/components/common/SmallButton/style.jsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 import Button from '@material-ui/core/Button';
+import { px } from '@/styles/themeUtil';
 
 export default {
   SmallButton: styled(Button)`
+    height: ${px(32)};
   `,
 };

--- a/web/src/hooks/channel/useGetChannel.js
+++ b/web/src/hooks/channel/useGetChannel.js
@@ -14,6 +14,7 @@ const CHECK_CHANNEL = gql`
         }
         channelName
         currentSlide
+        channelCode
       }
     }
   } 

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -54,6 +54,7 @@ const Channel = () => {
         initialSlide: data.channel.currentSlide,
         channelName: data.channel.channelName,
         masterName: data.channel.master.displayName,
+        channelCode: data.channel.channelCode,
       }}
     >
       <S.Channel>

--- a/web/src/utils/dom.js
+++ b/web/src/utils/dom.js
@@ -12,7 +12,21 @@ const computeScrollEndTop = (el) => {
   return wrapHeight > scrollerSize ? 0 : scrollerSize - wrapHeight;
 };
 
+/**
+ * @description param으로 들어온 값을 클립보드에 복사해주는 유틸함수
+ * @param {String} textToCopy
+ */
+const copyToClipboard = (textToCopy) => {
+  const element = document.createElement('textarea');
+  element.value = textToCopy;
+  document.body.appendChild(element);
+  element.select();
+  document.execCommand('copy');
+  document.body.removeChild(element);
+};
+
 export {
   pxToNum,
   computeScrollEndTop,
+  copyToClipboard,
 };


### PR DESCRIPTION
# 버튼 클릭 시, 채널 코드를 클립보드에 복사할 수 있도록 하는 CodeShareButton 컴포넌트 구현

## 해당 이슈 📎

- 공유 버튼을 이용해서 생성한 프레젠테이션 채널 코드를 복사하고, 공유할 수 있다. (#51)

## 변경 사항 🛠
- 채널 공유 UI 컴포넌트 구현
<img width="141" alt="스크린샷 2019-12-02 오후 6 15 48" src="https://user-images.githubusercontent.com/40539104/69946872-c6bad280-152f-11ea-8f42-ed939519ef4f.png">

- 채널 공유 버튼을 클릭하면, 접속중인 채널 코드를 복사할 수 있는 기능을 구현하였다.

## 테스트 ✨
> 없음

## 리뷰어 참고 사항 🙋‍♀️
> 없음
