### PR TITLE
채널 입장시, 로딩화면을 렌더링하고, 에러 발생 시, 에러 화면을 렌더링하도록 구현

### DIFF
--- a/web/src/components/main/ChannelListModal/ChannelCard/style.jsx
+++ b/web/src/components/main/ChannelListModal/ChannelCard/style.jsx
@@ -4,7 +4,7 @@ import { px, colorCommon, colorGray } from '@/styles';
 export default {
   ChannelCard: styled.div`
   width: 100%;
-  height: 20%;
+  height: 25%;
   background: ${colorCommon('white')};
   box-shadow: ${px(0)} ${px(2)} ${px(19)} rgba(134, 142, 150, 0.4);
   border-radius: ${px(3)};
@@ -32,7 +32,7 @@ export default {
   ChannelCode: styled.div`
     font-size: ${px(15)};
     color: ${colorGray(7)};
-    margin-top: ${px(40)};
+    margin-top: ${px(45)};
     margin-left: ${px(75)}
   `,
 };

--- a/web/src/components/main/CodeInput/CodeInput.jsx
+++ b/web/src/components/main/CodeInput/CodeInput.jsx
@@ -3,6 +3,8 @@ import { Redirect } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import S from './style';
 import { useGetChannelsByCode } from '@/hooks';
+import { ErrorModal } from '@/components/common';
+import { NO_EXIST_CHANNEL_MESSAGE, CODEINPUT_PLACEHOLDER } from '@/constants';
 
 const CodeInput = (props) => {
   const { SetShowChannelListModal, setChannels } = props;
@@ -24,17 +26,16 @@ const CodeInput = (props) => {
       const { channelId } = data.channels[0];
       return <Redirect to={`/channels/${channelId}`} />;
     } if (!channelCount) {
-      // TODO: 해당 코드를 갖고 있는 채널이 없을 경우 에러 모달 렌더링
-    } else {
-      SetShowChannelListModal(true);
-      setChannels(data.channels);
+      return <ErrorModal message={NO_EXIST_CHANNEL_MESSAGE} />;
     }
+    SetShowChannelListModal(true);
+    setChannels(data.channels);
   }
 
   return (
     <S.CodeInput>
       <S.CodeInputContent
-        placeholder="# 채널 코드"
+        placeholder={CODEINPUT_PLACEHOLDER}
         onChange={handleOnChange}
         value={channelCode}
       />

--- a/web/src/constants/main.js
+++ b/web/src/constants/main.js
@@ -1,4 +1,6 @@
 export const EMOJI_LIST = ['😀', '😃', '🤣', '😍', '😘', '🥳', '😻', '😽', '😇', '🦄', '🤓', '😎', '🤩'];
 export const TEMP_ERROR_MESSAGE = '일시적인 오류입니다. 다시 시도해주세요.';
 export const CREATING_CHANNEL_MESSAGE = '채널 생성중';
-export const NO_EXIST_CHANNEL = '존재하지 않는 채널입니다...';
+export const NO_EXIST_CHANNEL_MESSAGE = '존재하지 않는 채널입니다...';
+export const ENTERING_CHANNEL_MESSAGGGE = '채널 입장중';
+export const CODEINPUT_PLACEHOLDER = '채널 코드를 입력해주세요.';

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -11,7 +11,9 @@ import {
 import { Chat, Slide, ToolBar } from '@/components/channel';
 import { authByAnonymous } from '@/apis';
 import S from './style';
-import { NO_EXIST_CHANNEL } from '@/constants';
+import { NO_EXIST_CHANNEL_MESSAGE, ENTERING_CHANNEL_MESSAGGGE } from '@/constants';
+import { LoadingModal, ErrorModal } from '@/components/common';
+
 
 const Channel = () => {
   const { params: { channelId } } = useRouteMatch();
@@ -40,11 +42,11 @@ const Channel = () => {
     }
   }, [data]);
 
-  if (!data || loading) return null;
+  if (!data || loading) {
+    return (<LoadingModal message={ENTERING_CHANNEL_MESSAGGGE} />);
+  }
   if (data.status === 'not_exist') {
-    return (
-      <div>{NO_EXIST_CHANNEL}</div>
-    );
+    return (<ErrorModal message={NO_EXIST_CHANNEL_MESSAGE} />);
   }
 
   return (


### PR DESCRIPTION
# 채널 입장시, 로딩화면을 렌더링하고, 에러 발생 시, 에러 화면을 렌더링하도록 구현

## 해당 이슈 📎

- [Epic#31] 채널 코드를 입력할 수 있다. (#50)

## 변경 사항 🛠

- CodeInput 컴포넌트 내에서 입력한 채널 코드에 해당하는 채널이 없을 경우, ErrorModal을 렌더링한다.
- 채널 리스트 모달 컴포넌트에서 특정 채널 카드를 클릭했을 경우, 채널 데이터가 로딩될때까지 로딩 모달을 렌더링한다.
- 채널 코드를 입력하여 바로 채널에 입장할 경우, 채널 데이터가 로딩될때까지 로딩 모달을 렌더링한다.

## 테스트 ✨
> 없음

