### PR TITLE
자료 다운로드 버튼을 활성화할 수 있다.

### DIFF
--- a/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
@@ -1,15 +1,18 @@
 import React from 'react';
 import { SmallButton } from '@/components/common';
-import { useGetChannel } from '@/hooks';
+import { useChannelSelector } from '@/hooks';
 
 
 const SlideDownloadButton = () => {
-  const channelInfo = useGetChannel();
+  const channelFileUrl = useChannelSelector((state) => state.fileUrl);
+
   return (
     <>
       <SmallButton>
-        <span aria-label="slide-code-share-button" role="img">💾</span>
-        <span>다운로드</span>
+        <a href={channelFileUrl}>
+          <span aria-label="slide-code-share-button" role="img">💾</span>
+          <span>다운로드</span>
+        </a>
       </SmallButton>
     </>
   );

--- a/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
@@ -7,14 +7,12 @@ const SlideDownloadButton = () => {
   const channelFileUrl = useChannelSelector((state) => state.fileUrl);
 
   return (
-    <>
-      <SmallButton>
-        <a href={channelFileUrl}>
-          <span aria-label="slide-code-share-button" role="img">💾</span>
-          <span>다운로드</span>
-        </a>
-      </SmallButton>
-    </>
+    <SmallButton>
+      <a href={channelFileUrl}>
+        <span aria-label="slide-download-button" role="img">💾</span>
+        <span>다운로드</span>
+      </a>
+    </SmallButton>
   );
 };
 

--- a/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideDownloadButton/SlideDownloadButton.jsx
@@ -1,7 +1,18 @@
 import React from 'react';
+import { SmallButton } from '@/components/common';
+import { useGetChannel } from '@/hooks';
 
-const SlideDownloadButton = () => (
-  <></>
-);
+
+const SlideDownloadButton = () => {
+  const channelInfo = useGetChannel();
+  return (
+    <>
+      <SmallButton>
+        <span aria-label="slide-code-share-button" role="img">💾</span>
+        <span>다운로드</span>
+      </SmallButton>
+    </>
+  );
+};
 
 export default SlideDownloadButton;

--- a/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import S from './style';
 import { useChannelSelector } from '@/hooks';
 import CodeShareButton from './CodeShareButton';
+import SlideDownloadButton from './SlideDownloadButton';
 
 const SlideInfo = () => {
   const channelName = useChannelSelector((state) => state.channelName);
@@ -17,6 +18,7 @@ const SlideInfo = () => {
         </S.MasterName>
       </S.TitleWrapper>
       <S.SlideButtonsWrapper>
+        <SlideDownloadButton />
         <CodeShareButton />
       </S.SlideButtonsWrapper>
     </S.SlideInfo>

--- a/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
@@ -23,7 +23,6 @@ const SlideViewer = (props) => {
     isFullScreen,
     setFullScreen,
   } = props;
-  console.log(isFullScreen);
   const { mutate } = useSetCurrentSlide();
   const { currentSlide } = useSlideChanged(channelId);
   const { slideUrls, isMaster } = useChannelSelector((state) => state);

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -53,6 +53,7 @@ const Channel = () => {
     <ChannelContext.Provider
       value={{
         isMaster: data.isMaster,
+        fileUrl: data.channel.fileUrl,
         slideUrls: data.channel.slideUrls,
         initialSlide: data.channel.currentSlide,
         channelName: data.channel.channelName,


### PR DESCRIPTION
# 자료 다운로드 버튼을 활성화할 수 있다.

## 해당 이슈 📎

- [Epic#29, Epic#36] 자료 다운로드 버튼을 활성화할 수 있다.(#82)

## 변경 사항 🛠

- 채널 내에 다운로드 버튼 구현.
- 다운로드 버튼을 누르면 발표 자료 다운로드 가능

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음

