### PR TITLE
슬라이드 뷰어 이미지 비율 계산

### DIFF
--- a/server-api/src/apollo/resolvers/channels.js
+++ b/server-api/src/apollo/resolvers/channels.js
@@ -11,6 +11,7 @@ const createChannelInfo = (
   channelCode,
   slideUrls,
   fileUrl,
+  slideRatioList,
 ) => ({
   channelId,
   channelCode,
@@ -18,6 +19,7 @@ const createChannelInfo = (
   masterId: user.userId,
   slideUrls,
   fileUrl,
+  slideRatioList,
 });
 
 const createChannel = async (_, {
@@ -25,6 +27,7 @@ const createChannel = async (_, {
   channelCode,
   slideUrls,
   fileUrl,
+  slideRatioList,
 }, { user }) => {
   const newChannel = new Channels(
     createChannelInfo(
@@ -33,6 +36,7 @@ const createChannel = async (_, {
       channelCode,
       slideUrls,
       fileUrl,
+      slideRatioList,
     ),
   );
 

--- a/server-api/src/apollo/typeDefs/channels.js
+++ b/server-api/src/apollo/typeDefs/channels.js
@@ -5,6 +5,7 @@ type Channel {
   channelName: String
   maxHeadCount: Int
   slideUrls: [String]
+  slideRatioList: [Float]
   fileUrl: String
   channelCode: String!
   channelStatus: String
@@ -33,6 +34,7 @@ extend type Mutation {
     channelCode: String!,
     slideUrls: [String], 
     fileUrl: String,
+    slideRatioList: [Float],
   ): Channel,
   setCurrentSlide(channelId: String!, currentSlide: Int!): Channel
 }

--- a/server-api/src/models/channels.js
+++ b/server-api/src/models/channels.js
@@ -35,6 +35,9 @@ const ChannelSchema = new Schema({
   slideUrls: {
     type: Array,
   },
+  slideRatioList: {
+    type: Array,
+  },
   fileUrl: {
     type: String,
   },
@@ -64,6 +67,7 @@ ChannelSchema.methods.toPayload = async function toChannelPayload(...objs) {
     'channelName',
     'maxHeadCount',
     'slideUrls',
+    'slideRatioList',
     'fileUrl',
     'channelStatus',
     'currentSlide',

--- a/server-converter/src/@types/converter.d.ts
+++ b/server-converter/src/@types/converter.d.ts
@@ -15,4 +15,5 @@ export interface SlideImageOptions {
 export interface SlideInfo {
   path: string;
   page: number;
+  ratio: number;
 }

--- a/server-converter/src/@types/express.d.ts
+++ b/server-converter/src/@types/express.d.ts
@@ -7,6 +7,7 @@ declare global {
           slides: SlideInfo[]
           fileUrl: string
           slideUrls: string[]
+          slideRatioList: number[]
       }
   }
 }

--- a/server-converter/src/app.ts
+++ b/server-converter/src/app.ts
@@ -36,17 +36,19 @@ const start = () => {
     upload,
     removeTmp,
     (req, res) => {
-      const { slideUrls, fileUrl } = req;
+      const { slideUrls, fileUrl, slideRatioList } = req;
+
       res.status(200).json({
         status: 'ok',
         slideUrls,
         fileUrl,
+        slideRatioList,
       });
     },
   );
   app.use(handleError);
   app.listen('3000', () => {
-    console.log('welcome dropy converter!');
+    console.log('🔗 welcome dropy converter!');
   });
 };
 

--- a/server-converter/src/core/converter.ts
+++ b/server-converter/src/core/converter.ts
@@ -61,13 +61,20 @@ class SlideConverter implements SlideConverterSpec {
     const { name, format } = this.options;
     const output = `${outputPath}/${name(page)}.${format}`;
     const slideInfoPromise: Promise<SlideInfo> = new Promise((resolve, reject) => {
+      let slideRatio = 0;
+
       this.doGraphicWork(imageStream, page)
+        .size((err, size) => {
+          if (err) reject(err);
+          slideRatio = size.width / size.height;
+        })
         .write(output, (err) => {
           if (err) reject(err);
           else {
             resolve({
               path: output,
               page,
+              ratio: slideRatio,
             });
           }
         });

--- a/server-converter/src/middlewares/convert.ts
+++ b/server-converter/src/middlewares/convert.ts
@@ -17,6 +17,7 @@ const convertMiddleware: RequestHandler = (req, _, next) => {
 
   converter.convertToSlides(inputPath, outputPath).then((slides) => {
     req.slides = slides;
+    req.slideRatioList = slides.map((slide) => slide.ratio);
     next();
   });
 };

--- a/web/src/apis/convert.js
+++ b/web/src/apis/convert.js
@@ -10,12 +10,14 @@ const uploadFile = async (data) => {
     status,
     slideUrls,
     fileUrl,
+    slideRatioList,
   } = await response.json();
 
   return {
     status,
     slideUrls,
     fileUrl,
+    slideRatioList,
   };
 };
 

--- a/web/src/components/channel/Chat/Chat.jsx
+++ b/web/src/components/channel/Chat/Chat.jsx
@@ -17,7 +17,10 @@ const Chat = (props) => {
     <S.Chat isClosed={isClosed}>
       <ChatSort
         isClosed={isClosed}
-        toggleChatBox={() => setIsClosed(!isClosed)}
+        toggleChatBox={() => {
+          window.dispatchEvent(new Event('resize'));
+          setIsClosed(!isClosed);
+        }}
       />
       {!isClosed && (
         <>

--- a/web/src/components/channel/Slide/SlideViewer/Indicator/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/Indicator/style.jsx
@@ -8,6 +8,7 @@ export default {
     min-width: ${px(80)};
     width: 40%;
     position: absolute;
+    z-index: 200;
     top: 0;
     display: flex;
     flex-direction: column;

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
@@ -1,14 +1,51 @@
-import React from 'react';
+import React, {
+  useState,
+  useEffect,
+  useRef,
+} from 'react';
 import PropTypes from 'prop-types';
 import S from './style';
+import { useChannelSelector } from '@/hooks';
+import { pxToNum } from '@/utils/dom';
 
 const MainSlide = (props) => {
+  const [fitHeight, setFitHeight] = useState(false);
   const { page, slideUrls } = props;
+  const wrapperRef = useRef(null);
+  const canvasRef = useRef(null);
+  const slideRatioList = useChannelSelector((state) => state.slideRatioList);
+  const slideRatio = slideRatioList[page];
+
+  useEffect(() => {
+    const wrapperEl = wrapperRef.current;
+    const applyImageRatio = async () => window.requestAnimationFrame(() => {
+      const style = window.getComputedStyle(wrapperEl);
+      const width = pxToNum(style.width);
+      const height = pxToNum(style.height);
+      const wrapperRatio = width / height;
+      const fitHeightImage = wrapperRatio > slideRatio;
+      const canvasWidth = fitHeightImage ? height * slideRatio : width;
+      const canvasHeight = fitHeightImage ? height : width / slideRatio;
+
+      canvasRef.current.style.width = `${canvasWidth}px`;
+      canvasRef.current.style.height = `${canvasHeight}px`;
+      setFitHeight(fitHeightImage);
+    });
+    const handleResize = () => applyImageRatio();
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <S.MainSlide>
-      <S.SlideWrapper>
-        <S.SlideImg alt="slide" src={slideUrls[page]} />
+      <S.SlideWrapper ref={wrapperRef}>
+        <S.SlideImg alt="slide" src={slideUrls[page]} fitHeight={fitHeight} />
+        <S.Canvas ref={canvasRef} />
       </S.SlideWrapper>
     </S.MainSlide>
   );

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/style.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/style.jsx
@@ -3,7 +3,7 @@ import { px } from '@/styles/themeUtil';
 
 export default {
   MainSlide: styled.div`
-    display: inline-block;
+    box-sizing: border-box;
     width: 100%;
     height: 100%;
     padding: ${px(35)} 0;
@@ -15,17 +15,26 @@ export default {
   `,
   SlideImg: styled.img`
     position: absolute;
+    z-index: 100;
+    top: 50%;
+    left: 50%;
+    ${({ fitHeight }) => (fitHeight ? `
+    width: auto;
+    height:100%;
+    ` : `
+    width: 100%;
+    height: auto;
+    `)};
+    user-select: none;
+    border-radius: 3px;
+    box-shadow: 10px 2px 20px rgba(0, 0, 0, 0.1);
+    transform: translate(-50%, -50%);
+  `,
+  Canvas: styled.canvas`
+    position: absolute;
+    z-index: 200;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    user-select: none;
-    height:auto;
-    width:auto;
-    max-width: 100%;
-    max-height: 100%;
-    object-fit: contain;
-    border-radius: ${px(3)};
-    background-color: ${({ theme }) => theme.palette.common.white};
-    box-shadow: ${({ theme }) => theme.palette.shadow.slide};
   `,
 };

--- a/web/src/components/main/DropInput/DropInput.jsx
+++ b/web/src/components/main/DropInput/DropInput.jsx
@@ -28,6 +28,7 @@ const DropInput = () => {
       status,
       slideUrls,
       fileUrl,
+      slideRatioList,
     } = await uploadFile(formData);
 
     if (status === 'ok') {
@@ -37,6 +38,7 @@ const DropInput = () => {
           channelCode,
           slideUrls,
           fileUrl,
+          slideRatioList,
         },
       });
     } else {

--- a/web/src/components/main/DropZone/DropZone.jsx
+++ b/web/src/components/main/DropZone/DropZone.jsx
@@ -37,6 +37,7 @@ const DropZone = () => {
       status,
       slideUrls,
       fileUrl,
+      slideRatioList,
     } = await uploadFile(formData);
 
     if (status === 'ok') {
@@ -46,6 +47,7 @@ const DropZone = () => {
           slideUrls,
           fileUrl,
           channelCode,
+          slideRatioList,
         },
       });
     } else {

--- a/web/src/hooks/channel/useCreateChannel.js
+++ b/web/src/hooks/channel/useCreateChannel.js
@@ -7,12 +7,14 @@ const CREATE_CHANNEL = gql`
     $channelCode: String!,
     $slideUrls: [String], 
     $fileUrl: String,
+    $slideRatioList: [Float]
   ) {
     createChannel(
       channelId: $channelId,
       channelCode: $channelCode,
       slideUrls: $slideUrls,
-      fileUrl: $fileUrl
+      fileUrl: $fileUrl,
+      slideRatioList: $slideRatioList
     ) { 
       channelId
     }

--- a/web/src/hooks/channel/useGetChannel.js
+++ b/web/src/hooks/channel/useGetChannel.js
@@ -8,6 +8,7 @@ const CHECK_CHANNEL = gql`
       isMaster
       channel{
         slideUrls
+        slideRatioList
         fileUrl
         master{
           displayName

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -55,6 +55,7 @@ const Channel = () => {
         isMaster: data.isMaster,
         fileUrl: data.channel.fileUrl,
         slideUrls: data.channel.slideUrls,
+        slideRatioList: data.channel.slideRatioList,
         initialSlide: data.channel.currentSlide,
         channelName: data.channel.channelName,
         masterName: data.channel.master.displayName,


### PR DESCRIPTION
# 슬라이드 뷰어 이미지 비율 계산

## 해당 이슈 📎

- (스피커) 필기 도구를 이용해 슬라이드에 원하는 필기를 기입할 수 있다. (#86)

## 변경 사항 🛠

- 슬라이드 뷰어가 화면의 비율에 맞게 조정되도록 수정하였다.

## 테스트 ✨
> 없음
