### PR TITLE
채널에서 채팅 글 좋아요 클릭 시, 중복해서 생성되는 이슈 해결

### DIFF
--- a/web/src/components/channel/Chat/Chat.jsx
+++ b/web/src/components/channel/Chat/Chat.jsx
@@ -1,16 +1,19 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useGetUserStatus, useChatChanged } from '@/hooks';
+import {
+  useChatChanged,
+  useInitChat,
+} from '@/hooks';
 import ChatInput from './ChatInput';
 import ChatLogs from './ChatLogs';
 import ChatSort from './ChatSort';
 import S from './style';
 
 const Chat = (props) => {
-  const { channelId } = props;
+  const { channelId, userId } = props;
   const [isClosed, setIsClosed] = useState(false);
-  const { userId } = useGetUserStatus();
 
+  useInitChat(channelId);
   useChatChanged(channelId);
 
   return (
@@ -34,6 +37,7 @@ const Chat = (props) => {
 
 Chat.propTypes = {
   channelId: PropTypes.string.isRequired,
+  userId: PropTypes.string.isRequired,
 };
 
 export default Chat;

--- a/web/src/components/channel/Chat/Chat.jsx
+++ b/web/src/components/channel/Chat/Chat.jsx
@@ -1,9 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  useChatChanged,
-  useInitChat,
-} from '@/hooks';
+import { useChatChanged, useInitChat } from '@/hooks';
 import ChatInput from './ChatInput';
 import ChatLogs from './ChatLogs';
 import ChatSort from './ChatSort';

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCards.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCards.jsx
@@ -18,7 +18,6 @@ const ChatCards = (props) => {
       }) => (
         <S.ChatLog key={`chat-log-${id}`}>
           <ChatCard
-            id={id}
             author={author}
             message={message}
             isLiked={likes.includes(userId)}

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
@@ -54,7 +54,7 @@ const S = {
     margin-top: ${px(5)};
     font-size: ${px(16)};
     line-height: ${px(21)};
-    word-break: break-all;
+    word-break: break-word;
     word-wrap: break-word;
     white-space: pre-wrap;
     color: ${colorGray(8)};

--- a/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
@@ -5,7 +5,6 @@ import { useGetChatsCached } from '@/hooks';
 import { computeScrollEndTop } from '@/utils/dom';
 import {
   CHAT_ADDED,
-  CHAT_SORT_BY_LIKE,
   CHAT_SORT_BY_RECENT,
 } from '@/constants';
 import S from './style';

--- a/web/src/hooks/channel/chat/useInitChat.js
+++ b/web/src/hooks/channel/chat/useInitChat.js
@@ -36,7 +36,9 @@ const useInitChat = (channelId) => {
     });
   };
   const writeChatCache = () => {
-    if (!query.called || query.loading) return;
+    const isNotComponentMountEvent = !query.called || query.loading;
+
+    if (isNotComponentMountEvent) return;
 
     const { chatLogs } = client.readQuery({ query: GET_CHAT_CACHED });
     const logs = query.data.getChatLogs;

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -5,7 +5,6 @@ import {
   useLogin,
   useGetUserStatus,
   useGetChannel,
-  useInitChat,
   useAddUserHistory,
 } from '@/hooks';
 import { Chat, Slide, ToolBar } from '@/components/channel';
@@ -22,7 +21,6 @@ const Channel = () => {
   const userStatus = useGetUserStatus();
   const { mutate } = useAddUserHistory();
 
-  useInitChat(channelId);
   useEffect(() => {
     if (userStatus.token) return;
     authByAnonymous().then(({ token, user }) => logIn({
@@ -65,7 +63,7 @@ const Channel = () => {
       <S.Channel>
         <ToolBar />
         <Slide channelId={channelId} />
-        <Chat channelId={channelId} />
+        <Chat channelId={channelId} userId={userStatus.userId} />
       </S.Channel>
     </ChannelContext.Provider>
   );


### PR DESCRIPTION
# 채널에서 채팅 글 좋아요 클릭 시, 중복해서 생성되는 이슈 해결

## 해당 이슈 📎

- 채널에서 채팅 글 좋아요 클릭 시, 채팅글이 여러개 중복 생성되는 이슈 발생 (#99)

## 변경 사항 🛠

- `useQuery`를 활용하던 부분을 `useLazyQuery`를 이용해서 캐시 초기화시점을 컴포넌트 마운트 시점과 동기화

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음

