### PR TITLE
[이미림]w5_리뷰요청_채널_슬라이드_이미지와_캔버스의_크기_자동조정_기능_구현

### DIFF
--- a/Chat.jsx
+++ b/Chat.jsx
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useGetUserStatus, useChatChanged } from '@/hooks';
+import ChatInput from './ChatInput';
+import ChatLogs from './ChatLogs';
+import ChatSort from './ChatSort';
+import S from './style';
+
+const Chat = (props) => {
+  const { channelId } = props;
+  const [isClosed, setIsClosed] = useState(false);
+  const { userId } = useGetUserStatus();
+
+  useChatChanged(channelId);
+
+  return (
+    <S.Chat isClosed={isClosed}>
+      <ChatSort
+        isClosed={isClosed}
+        toggleChatBox={() => {
+          window.dispatchEvent(new Event('resize'));
+          setIsClosed(!isClosed);
+        }}
+      />
+      {!isClosed && (
+        <>
+          <ChatLogs channelId={channelId} userId={userId} />
+          <ChatInput channelId={channelId} />
+        </>
+      )}
+    </S.Chat>
+  );
+};
+
+Chat.propTypes = {
+  channelId: PropTypes.string.isRequired,
+};
+
+export default Chat;

--- a/MainSlide/MainSlide.jsx
+++ b/MainSlide/MainSlide.jsx
@@ -12,7 +12,6 @@ const MainSlide = (props) => {
   const {
     page,
     slideUrls,
-    // isToolBarActive,
     isPenToolActive,
   } = props;
   const [fitHeight, setFitHeight] = useState(false);
@@ -20,33 +19,6 @@ const MainSlide = (props) => {
   const canvasRef = useRef(null);
   const slideRatioList = useChannelSelector((state) => state.slideRatioList);
   const slideRatio = slideRatioList[page];
-
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    const ctx = canvas.getContext('2d');
-    const pos = { x: 0, y: 0 };
-    const setPosition = (event) => {
-      pos.x = event.clientX;
-      pos.y = event.clientY;
-    };
-    const draw = (event) => {
-      if (event.buttons !== 1) return;
-
-      ctx.beginPath();
-
-      ctx.lineWidth = 5;
-      ctx.lineCap = 'round';
-      ctx.strokeStyle = '#c0392b';
-
-      ctx.moveTo(pos.x, pos.y); // from
-      setPosition(event);
-      ctx.lineTo(pos.x, pos.y); // to
-
-      ctx.stroke();
-    };
-    canvas.addEventListener('mousemove', draw);
-    canvas.addEventListener('mousedown', setPosition);
-  }, []);
 
   useEffect(() => {
     const wrapperEl = wrapperRef.current;

--- a/MainSlide/MainSlide.jsx
+++ b/MainSlide/MainSlide.jsx
@@ -1,0 +1,92 @@
+import React, {
+  useState,
+  useEffect,
+  useRef,
+} from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+import { useChannelSelector } from '@/hooks';
+import { pxToNum } from '@/utils/dom';
+
+const MainSlide = (props) => {
+  const {
+    page,
+    slideUrls,
+    // isToolBarActive,
+    isPenToolActive,
+  } = props;
+  const [fitHeight, setFitHeight] = useState(false);
+  const wrapperRef = useRef(null);
+  const canvasRef = useRef(null);
+  const slideRatioList = useChannelSelector((state) => state.slideRatioList);
+  const slideRatio = slideRatioList[page];
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const ctx = canvas.getContext('2d');
+    const pos = { x: 0, y: 0 };
+    const setPosition = (event) => {
+      pos.x = event.clientX;
+      pos.y = event.clientY;
+    };
+    const draw = (event) => {
+      if (event.buttons !== 1) return;
+
+      ctx.beginPath();
+
+      ctx.lineWidth = 5;
+      ctx.lineCap = 'round';
+      ctx.strokeStyle = '#c0392b';
+
+      ctx.moveTo(pos.x, pos.y); // from
+      setPosition(event);
+      ctx.lineTo(pos.x, pos.y); // to
+
+      ctx.stroke();
+    };
+    canvas.addEventListener('mousemove', draw);
+    canvas.addEventListener('mousedown', setPosition);
+  }, []);
+
+  useEffect(() => {
+    const wrapperEl = wrapperRef.current;
+    const applyImageRatio = async () => window.requestAnimationFrame(() => {
+      const style = window.getComputedStyle(wrapperEl);
+      const width = pxToNum(style.width);
+      const height = pxToNum(style.height);
+      const wrapperRatio = width / height;
+      const fitHeightImage = wrapperRatio > slideRatio;
+      const canvasWidth = fitHeightImage ? height * slideRatio : width;
+      const canvasHeight = fitHeightImage ? height : width / slideRatio;
+
+      canvasRef.current.style.width = `${canvasWidth}px`;
+      canvasRef.current.style.height = `${canvasHeight}px`;
+      setFitHeight(fitHeightImage);
+    });
+    const handleResize = () => applyImageRatio();
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [page]);
+
+  return (
+    <S.MainSlide>
+      <S.SlideWrapper ref={wrapperRef}>
+        <S.SlideImg alt="slide" src={slideUrls[page]} fitHeight={fitHeight} />
+        <S.Canvas ref={canvasRef} />
+      </S.SlideWrapper>
+    </S.MainSlide>
+  );
+};
+
+MainSlide.propTypes = {
+  page: PropTypes.number.isRequired,
+  slideUrls: PropTypes.arrayOf(PropTypes.string).isRequired,
+  isPenToolActive: PropTypes.bool.isRequired,
+};
+
+export default MainSlide;

--- a/MainSlide/index.js
+++ b/MainSlide/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainSlide';

--- a/MainSlide/style.jsx
+++ b/MainSlide/style.jsx
@@ -1,0 +1,41 @@
+import styled from 'styled-components';
+import { px } from '@/styles/themeUtil';
+
+export default {
+  MainSlide: styled.div`
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    padding: ${px(35)} 0;
+  `,
+  SlideWrapper: styled.div`
+    width:100%;
+    height:100%;
+    position:relative;
+  `,
+  SlideImg: styled.img`
+    position: absolute;
+    z-index: 100;
+    top: 50%;
+    left: 50%;
+    ${({ fitHeight }) => (fitHeight ? `
+    width: auto;
+    height:100%;
+    ` : `
+    width: 100%;
+    height: auto;
+    `)};
+    user-select: none;
+    border-radius: 3px;
+    box-shadow: 10px 2px 20px rgba(0, 0, 0, 0.1);
+    transform: translate(-50%, -50%);
+  `,
+  Canvas: styled.canvas`
+    position: absolute;
+    z-index: 200;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    border: 1px solid blue;
+  `,
+};


### PR DESCRIPTION
## 해당 이슈 📎

- (스피커) 필기 도구를 이용해 슬라이드에 원하는 필기를 기입할 수 있다. (#86)

## 변경 사항 🛠
 - 캐로샐로 구현된 슬라이드를 양옆으로 넘기거나, window의 크기가 변하거나, 채팅창이 토글될 때, 슬라이드 이미지와 캔버스의 넓이, 높이, 위치가 자동적으로 resize되도록 수정하였습니다.

## 질문사항 
- 미리 계산된 슬라이드 이미지의 비율을 이용해 canvas와 이미지를 감싸고 있는 SlideWrapper 컴포넌트의 넓이와 높이를 계산하는 로직이 적절한 시점(useEffect)에 적절하게 구현되었는지 궁금합니다.
- 하나의 화면에 슬라이드 이미지와 채팅 화면이 함께 존재하는데, 채팅창을 토글할 때마다, 슬라이드 이미지의 크기를 조정해주기 위해 `window.dispatchEvent(new Event('resize'));`와 같은 방식으로 이벤트를 호출하는 방식을 사용하고 있는데 이 방식이 적절한지 궁금하고, 더 좋은 방법이 있는지 궁금합니다!