### PR TITLE
채널 자료를 다운 받을 때, 파일명이 변경 되어야 한다. (#137)

### DIFF
--- a/server-converter/src/middlewares/upload.ts
+++ b/server-converter/src/middlewares/upload.ts
@@ -39,13 +39,13 @@ const uploadMiddleware: RequestHandler = (req: any, _, next) => {
   const uploadFile: Promise<string> = uploadToObjectStorage(
     req.file.path,
     channelId,
-    'index',
+    req.file.originalname,
     true,
   );
   const uploadSlides: Promise<string>[] = req.slides.map((slide) => uploadToObjectStorage(
     slide.path,
     channelId,
-    `${slide.page}`,
+    `${slide.page}.jpg`,
     false,
   ));
 


### PR DESCRIPTION
# 채널 자료를 다운 받을 때, 파일명이 변경 되어야 한다. (#137)

## 해당 이슈 📎

- 채널 자료를 다운 받을 때, 파일명이 변경 되어야 한다. (#137)

## 변경 사항 🛠

- 기존의 pdf파일은 기존의 파일명을 가질 수 있도록 originalname을 사용.
- 컨버터로 쪼개진 파일은 기존의 숫자가 아닌 뒤에 jpg형식을 추가.

## 테스트 ✨

> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음
