### PR TITLE
해쉬태그(#)로 질문 채팅을 생성 구현 완료

### DIFF
--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import S from './style';
+import { useGetQuestion, useDispatch } from '@/hooks';
 
 const ChatCard = (props) => {
   const {
@@ -10,11 +11,24 @@ const ChatCard = (props) => {
     likesCount,
     handleClickLike,
   } = props;
+  const [tokens] = useGetQuestion(message);
+  const dispatch = useDispatch();
+
+  const handleSetPage = (token) => () => {
+    const nextPage = token.split('#')[1];
+    dispatch({ type: 'SET_PAGE', payload: { page: nextPage - 1 } });
+  };
 
   return (
-    <S.ChatCard>
+    <S.ChatCard isQuestion={tokens ? 1 : 0}>
       <S.Author>{author.displayName}</S.Author>
-      <S.Message>{message}</S.Message>
+      <S.Message>
+        {!tokens ? message : tokens.map(({ token, isQtag }, index) => (isQtag ? (
+          <S.Question key={index} onClick={handleSetPage(token)}>
+            {token}
+          </S.Question>
+        ) : token))}
+      </S.Message>
       <S.AreaButtons>
         <S.LikeButton onClick={handleClickLike}>
           <S.LikeIcon isActive={isLiked} />

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import S from './style';
-import { useGetQuestion, useDispatch } from '@/hooks';
+import { useGetQuestion, useDispatch, useChannelSelector } from '@/hooks';
 
 const ChatCard = (props) => {
   const {
@@ -13,9 +13,12 @@ const ChatCard = (props) => {
   } = props;
   const [tokens] = useGetQuestion(message);
   const dispatch = useDispatch();
-
+  const slideUrls = useChannelSelector((state) => state.slideUrls);
   const handleSetPage = (token) => () => {
     const nextPage = token.split('#')[1];
+    if (nextPage > slideUrls.length) return;
+
+    dispatch({ type: 'SET_ISSYNC', payload: { isSync: false } });
     dispatch({ type: 'SET_PAGE', payload: { page: nextPage - 1 } });
   };
 

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
@@ -78,6 +78,7 @@ const S = {
     cursor: pointer;
     &:hover{
       text-decoration: underline;
+      color: ${({ theme }) => theme.palette.link};
     }
   `,
   AreaButtons: styled.div`

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/style.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { px, colorGray } from '@/styles';
+import { px, colorGray, colorYellow } from '@/styles';
 import { CHAT_LIKE_ICON_PATH } from '@/constants';
 
 const LikeIcon = styled(({ isActive, className }) => (
@@ -42,7 +42,20 @@ const S = {
     padding: ${px(6)} ${px(19)};
     border-radius: ${px(3)};
     box-shadow: 0px 2px 10px rgba(73, 80, 87, 0.16);
-    background-color: #fff;
+    background-color: ${({ isQuestion }) => (
+    isQuestion
+      ? colorYellow('light')
+      : '#fff'
+  )};
+    animation: ${({ isQuestion }) => (
+    isQuestion
+      ? 'colorChange 0.8s ease-out'
+      : 'none'
+  )};
+    @keyframes colorChange {
+      0% { background-color: ${colorYellow(2)}; }
+      100% { background-color: ${colorYellow('light')};}
+    }
   `,
   Author: styled.em`
     display: block;
@@ -58,6 +71,14 @@ const S = {
     word-wrap: break-word;
     white-space: pre-wrap;
     color: ${colorGray(8)};
+  `,
+  Question: styled.span`
+    font-weight: bold;
+    color: '#000'; 
+    cursor: pointer;
+    &:hover{
+      text-decoration: underline;
+    }
   `,
   AreaButtons: styled.div`
     height: ${px(20)};

--- a/web/src/components/channel/Slide/Slide.jsx
+++ b/web/src/components/channel/Slide/Slide.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { useSlideChanged } from '@/hooks';
+import { useChannelSelector, useSlideChanged, useDispatch } from '@/hooks';
 import S from './style';
 import SlideStatus from './SlideStatus';
 import SlideViewer from './SlideViewer';
@@ -9,12 +9,12 @@ import SlideInfo from './SlideInfo';
 const Slide = (props) => {
   const { channelId, toolBarDispatch } = props;
   const { currentSlide } = useSlideChanged(channelId);
-  const [isSync, setSync] = useState(true);
+  const isSync = useChannelSelector((state) => state.isSync);
   const [isFullScreen, setFullScreen] = useState(false);
-  const [page, setPage] = useState(0);
+  const dispatch = useDispatch();
   const handleSync = (state) => () => {
-    setPage(currentSlide);
-    setSync(state);
+    dispatch({ type: 'SET_PAGE', payload: { page: currentSlide } });
+    dispatch({ type: 'SET_ISSYNC', payload: { isSync: state } });
   };
 
   return (
@@ -26,12 +26,8 @@ const Slide = (props) => {
         toolBarDispatch={toolBarDispatch}
       />
       <SlideViewer
-        isSync={isSync}
-        setSync={setSync}
         isFullScreen={isFullScreen}
         setFullScreen={setFullScreen}
-        page={page}
-        setPage={setPage}
         channelId={channelId}
       />
       <SlideInfo />

--- a/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
@@ -6,6 +6,7 @@ import {
   useSetCurrentSlide,
   useSlideChanged,
   useSyncSlide,
+  useDispatch,
 } from '@/hooks';
 import { moveSlide, moveSlidePossible } from '@/utils/slide';
 import { FullScreen } from '@/components/common';
@@ -18,16 +19,19 @@ import PageNumber from './PageNumber';
 const SlideViewer = (props) => {
   const {
     channelId,
-    isSync,
-    setSync,
-    page,
-    setPage,
     isFullScreen,
     setFullScreen,
   } = props;
   const { mutate } = useSetCurrentSlide();
   const { currentSlide } = useSlideChanged(channelId);
-  const { slideUrls, isMaster, isChat } = useChannelSelector((state) => state);
+  const {
+    slideUrls,
+    isMaster,
+    isChat,
+    isSync,
+    page,
+  } = useChannelSelector((state) => state);
+  const dispatch = useDispatch();
   const syncSlide = useSyncSlide(
     isMaster,
     isSync,
@@ -38,12 +42,14 @@ const SlideViewer = (props) => {
 
   directionKey[KEYCODE_BACK] = false;
   directionKey[KEYCODE_FOWARD] = true;
-
+  const setPage = (next) => {
+    dispatch({ type: 'SET_PAGE', payload: { page: next } });
+  };
   const handleSetPage = (direction) => () => {
     const sync = !isMaster && isSync ? currentSlide : page;
     if (!moveSlidePossible(direction, sync, slideUrls.length)) return;
     if (!isMaster && isSync) {
-      setSync(false);
+      dispatch({ type: 'SET_ISSYNC', payload: { isSync: false } });
       moveSlide(currentSlide, direction, setPage);
     } else {
       moveSlide(page, direction, setPage);
@@ -67,7 +73,7 @@ const SlideViewer = (props) => {
     mutate({ variables: { channelId, currentSlide: page } });
   }, [page]);
 
-  const screenChange = (e) => setFullScreen(e);
+  const screenChange = (event) => setFullScreen(event);
   const IndicatorRender = Object.values(directionKey).map((direction) => (
     <Indicator
       key={direction}
@@ -100,10 +106,6 @@ const SlideViewer = (props) => {
 
 SlideViewer.propTypes = {
   channelId: PropTypes.string.isRequired,
-  isSync: PropTypes.bool.isRequired,
-  setSync: PropTypes.func.isRequired,
-  page: PropTypes.number.isRequired,
-  setPage: PropTypes.func.isRequired,
   isFullScreen: PropTypes.bool.isRequired,
   setFullScreen: PropTypes.func.isRequired,
 };

--- a/web/src/hooks/channel/chat/index.js
+++ b/web/src/hooks/channel/chat/index.js
@@ -4,3 +4,4 @@ export { default as useChatChanged } from './useChatChanged';
 export { default as useGetChatsCached } from './useGetChatsCached';
 export { default as useInitChat } from './useInitChat';
 export { default as useLikeChat } from './useLikeChat';
+export { default as useGetQuestion } from './useGetQuestion';

--- a/web/src/hooks/channel/chat/useGetQuestion.js
+++ b/web/src/hooks/channel/chat/useGetQuestion.js
@@ -1,0 +1,31 @@
+const useGetQuestion = (text) => {
+  const regex = /(#\d+)/g;
+  const questions = [...text.matchAll(regex)];
+  const isQuestion = !!questions.length;
+  const tags = questions.map((q) => q[0]);
+
+  if (!isQuestion) return [null];
+
+  const sliceIndex = questions.reduce((result, question) => {
+    const { index } = question;
+    const lastIndex = question[0].length + index;
+    if (index) result.push(index);
+    result.push(lastIndex);
+
+    return result;
+  }, [0]);
+
+  const tokens = sliceIndex.reduce((array, start, index, origin) => {
+    const last = origin[index + 1];
+    const token = text.substring(start, last);
+    const isQtag = !!tags.includes(token);
+
+    array.push({ token, isQtag });
+
+    return array;
+  }, []);
+
+  return [tokens];
+};
+
+export default useGetQuestion;

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -43,6 +43,7 @@ const Channel = (props) => {
   return (
     <ChannelProvider
       value={{
+        channelId,
         isMaster: data.isMaster,
         fileUrl: data.channel.fileUrl,
         slideUrls: data.channel.slideUrls,

--- a/web/src/reducers/channel.js
+++ b/web/src/reducers/channel.js
@@ -1,5 +1,7 @@
 export const initialChannelState = {
   isChat: false,
+  isSync: true,
+  page: 0,
 };
 
 const channelReducer = (state, action) => {
@@ -8,6 +10,16 @@ const channelReducer = (state, action) => {
       return {
         ...state,
         isChat: action.payload.isChat,
+      };
+    case 'SET_ISSYNC':
+      return {
+        ...state,
+        isSync: action.payload.isSync,
+      };
+    case 'SET_PAGE':
+      return {
+        ...state,
+        page: action.payload.page,
       };
     default:
       return state;

--- a/web/src/styles/theme.js
+++ b/web/src/styles/theme.js
@@ -24,6 +24,7 @@ export default createMuiTheme({
     naver: '#04d404',
     kakao: '#ffe812',
     google: '#fff',
+    link: '#4780CE',
     dropyGray: {
       0: '#f8f9fa',
       1: '#f1f3f5',
@@ -37,7 +38,7 @@ export default createMuiTheme({
       9: '#212529',
     },
     dropyYellow: {
-      light: '#FFFDF1',
+      light: '#FFFBE5',
       0: '#fff9db',
       1: '#fff3bf',
       2: '#ffec99',

--- a/web/src/styles/theme.js
+++ b/web/src/styles/theme.js
@@ -37,6 +37,7 @@ export default createMuiTheme({
       9: '#212529',
     },
     dropyYellow: {
+      light: '#FFFDF1',
       0: '#fff9db',
       1: '#fff3bf',
       2: '#ffec99',


### PR DESCRIPTION
# 해쉬태그(#)로 질문 채팅을 생성 구현 완료

## 해당 이슈 📎
- 사용자는 해쉬태그로 질문을 생성할 수 있음 (#130)

## 변경 사항 🛠

- 채팅 문자열 파싱 로직 구현
- 질문 채팅 토큰 반환 훅 구현
- 질문 채팅 UI구현
- 채널 reducer에 페이지와 동기화 상태 추가하여 전역관리 가능하도록 수정

## 리뷰어 참고 사항 🙋‍♀️

> 없음

