### PR TITLE
[김재원]w6_리뷰요청_리액트에서_애니메이션_사용_및_모듈화

### DIFF
--- a/server-converter/src/core/Converter/Converter.ts
+++ b/server-converter/src/core/Converter/Converter.ts
@@ -1,0 +1,58 @@
+import { getExtension } from '../../utils/pathParser';
+import {
+  ConverterEngine,
+  SlideInfo,
+  OutputNaming,
+} from '../../@types/converter';
+import PdfConverter from './PdfConverter';
+
+class Converter {
+  private inputPath: string;
+  private outputPath: string;
+  private outputNaming: OutputNaming;
+  public engine: ConverterEngine;
+
+  constructor(
+    inputPath: string,
+    outputPath: string,
+    outputNaming: OutputNaming,
+  ) {
+    this.inputPath = inputPath;
+    this.outputPath = outputPath;
+    this.outputNaming = outputNaming;
+  }
+
+  async init() {
+    const fileExtension = getExtension(this.inputPath).toLowerCase();
+
+    if (fileExtension === 'pdf') {
+      this.engine = new PdfConverter(
+        this.inputPath,
+        this.outputPath,
+        this.outputNaming,
+      );
+    }
+
+    try {
+      await this.engine.init();
+    } catch (err) {
+      this.logError(err);
+    }
+  }
+
+  async convert(): Promise<SlideInfo[]> {
+    try {
+      const slideInfos: SlideInfo[] = await this.engine.convert();
+
+      return slideInfos;
+    } catch (err) {
+      this.logError(err);
+    }
+  }
+
+  private logError(err) {
+    console.error(`[Converter Error] ${err.message}`);
+  }
+}
+
+export default Converter;

--- a/server-converter/src/core/Converter/PdfConverter.ts
+++ b/server-converter/src/core/Converter/PdfConverter.ts
@@ -1,0 +1,71 @@
+import * as Path from 'path';
+import * as EventEmitter from 'events';
+import {
+  ConverterEngine,
+  OutputNaming,
+  SlideInfo,
+} from '../../@types/converter';
+import SimpleGm from './SimpleGm';
+
+class PdfConverter extends EventEmitter implements ConverterEngine {
+  private inputPath: string;
+  private outputPath: string;
+  private outputNaming: OutputNaming;
+  private sgms: SimpleGm[];
+  private pageLength: number;
+
+  constructor(
+    inputPath: string,
+    outputPath: string,
+    outputNaming: OutputNaming,
+  ) {
+    super();
+    this.inputPath = inputPath;
+    this.outputPath = outputPath;
+    this.outputNaming = outputNaming;
+    this.sgms = [];
+    this.pageLength = 0;
+  }
+
+  async init(): Promise<void> {
+    const pages: number[] = await SimpleGm.getPdfPages(this.inputPath);
+
+    this.pageLength = pages.length;
+    this.sgms = pages.map((page) => {
+      const fileName: string = `${this.outputNaming(page)}.jpg`;
+      const outputPath: string = Path.join(this.outputPath, fileName);
+      const sgm: SimpleGm = SimpleGm.createAndSelect(this.inputPath, outputPath, page);
+
+      return sgm;
+    });
+  }
+
+  async convert(): Promise<SlideInfo[]> {
+    const slideInfos: SlideInfo[] = [];
+    const handleConvertFinished = (slideInfo: SlideInfo) => {
+      const { page } = slideInfo;
+
+      slideInfos.push(slideInfo);
+      this.emit('progress', { page, length: this.pageLength });
+    };
+
+    try {
+      this.sgms.forEach((sgm) => sgm.resetStream());
+      await this.sgms.reduce((chain, sgm) => (
+        chain.then(() => sgm.optimize().write().then(handleConvertFinished))
+      ), Promise.resolve(null));
+      this.removeAllListeners('progress');
+
+      return slideInfos;
+    } catch (err) {
+      this.removeAllListeners('progress');
+      throw err;
+    }
+  }
+
+  getPageLength() {
+    return this.pageLength;
+  }
+}
+
+export default PdfConverter;

--- a/server-converter/src/core/Converter/SimpleGm.ts
+++ b/server-converter/src/core/Converter/SimpleGm.ts
@@ -1,0 +1,92 @@
+import * as gm from 'gm';
+import * as fs from 'fs';
+import { promisify } from 'util';
+import { GmOptimizeOptions, SlideInfo } from '../../@types/converter';
+
+const optimizeOptions: GmOptimizeOptions = {
+  quality: 100,
+  resolution: 144,
+  compression: 'JPEG2000',
+};
+
+class SimpleGm {
+  static createAndSelect(inputPath: string, outputPath: string, page: number) {
+    const sgm = new SimpleGm(inputPath, outputPath);
+
+    sgm.selectPage(page);
+
+    return sgm;
+  }
+
+  static async getPdfPages(inputPath: string): Promise<number[]> {
+    const readStream: fs.ReadStream = fs.createReadStream(inputPath);
+    const pdf: gm.State = gm(readStream);
+    const identify = promisify<string, string>(pdf.identify.bind(pdf));
+    const pageStr: string = await identify('%p ');
+    const pageStrArr: string[] = pageStr.split(/\s+/);
+    const pages: number[] = pageStrArr.map((str) => +str)
+      .filter((page) => !Number.isNaN(page));
+
+    return pages;
+  }
+
+  inputPath: string;
+  outputPath: string;
+  readStream: fs.ReadStream;
+  writeStream: fs.WriteStream;
+  state: gm.State;
+  page: number;
+
+  constructor(inputPath: string, outputPath: string) {
+    this.inputPath = inputPath;
+    this.outputPath = outputPath;
+    this.page = 0;
+    this.resetStream();
+  }
+
+  async write(): Promise<SlideInfo> {
+    const stream: fs.WriteStream = this.writeStream;
+    const outputPath: string = <string>stream.path;
+    const slideInfo: SlideInfo = { path: outputPath, ratio: 1.7777777777777777, page: this.page };
+    const size: any = await promisify(this.state.size.bind(this.state));
+    const ratio: number = size.width / size.height;
+
+    if (!Number.isNaN(ratio)) slideInfo.ratio = ratio;
+
+    return new Promise((resolve) => {
+      stream.once('close', () => resolve(slideInfo));
+      this.resetStream();
+      this.optimize();
+      this.state.stream('jpeg').pipe(stream);
+    });
+  }
+
+  selectPage(page: number): SimpleGm {
+    this.page = page;
+
+    return this;
+  }
+
+  resetStream() {
+    this.readStream = fs.createReadStream(this.inputPath);
+    this.writeStream = fs.createWriteStream(this.outputPath);
+    this.state = gm(this.readStream, `${this.readStream.path}[${this.page - 1}]`);
+  }
+
+  optimize(): SimpleGm {
+    const {
+      quality,
+      resolution,
+      compression,
+    } = optimizeOptions;
+
+    this.state = this.state
+      .density(resolution, resolution)
+      .quality(quality)
+      .compress(compression);
+
+    return this;
+  }
+}
+
+export default SimpleGm;

--- a/web/src/components/common/Modal/Modal.jsx
+++ b/web/src/components/common/Modal/Modal.jsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+
+const Modal = (props) => {
+  const { children, isShown } = props;
+  const modalRef = useRef(null);
+  const showModal = () => {
+    modalRef.current.style.display = 'block';
+    window.requestAnimationFrame(() => {
+      modalRef.current.style.opacity = 1;
+    });
+  };
+  const hideModal = () => {
+    modalRef.current.style.opacity = 0;
+  };
+
+  useEffect(() => {
+    const afterModalHidden = () => {
+      if (+modalRef.current.style.opacity === 0) modalRef.current.style.display = 'none';
+    };
+    modalRef.current.addEventListener('transitionend', afterModalHidden);
+
+    return () => {
+      modalRef.current.removeEventListener('transitionend', afterModalHidden);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isShown) showModal();
+    else hideModal();
+  }, [isShown]);
+
+  return (
+    <S.Modal ref={modalRef}>
+      <S.ModalContent>{children}</S.ModalContent>
+    </S.Modal>
+  );
+};
+
+Modal.propTypes = {
+  children: PropTypes.element.isRequired,
+  isShown: PropTypes.bool,
+};
+
+export default Modal;


### PR DESCRIPTION
# [김재원]w6_리뷰요청_리액트에서_애니메이션_사용_및_모듈화

## 해당 이슈 📎
- [Epic#20] 채널 제목을 수정할 수 있다 (#127)
- [컨버터 서버 성능 개선] 방어 시스템 설계 (#80)

## 개발상황 요약 📝
1. 채널 제목을 수정하기 위해서 모달UI를 만든 상황입니다.  
    - 모달에 대해서 fadeIn/Out 애니메이션을 적용하고 싶은데 문제가 있습니다.  
    - fadeIn의 경우 `componentDidMount()` 또는 `useEffect()` 를 통해 적용 가능할 듯한데,  
    - fadeOut의 경우 애니메이션이 끝나고나서 언마운트 시킬 수 있는 방법을 찾지 못했습니다.
    - 따라서 `isShown` 프롭스를 통해 핸들링 할 수 있도록 구현했습니다.
2. 공유드린 모듈은 `gm.js` 를 사용해서 pdf 포맷을 각 페이지 별로 jpg 포맷의 이미지로 변환하는 모듈입니다.
    - pdf 파일경로, output 경로, 그리고 output 파일 네이밍 규칙을 주면 변환할 수 있습니다.
    - 변환과정에서 각 페이지마다 변환이 완료되면 진행상태를 `progress` 이벤트로 전파합니다.
    - `gm.js`가 콜백 방식으로 구현된 모듈이라 `promisify`를 활용했습니다.
    - 현재는 pdf 만 가능하지만 추후 ppt, 마크다운까지 확장할 계획을 갖고 설계했습니다.

## 리뷰어님 참고 사항 🙋‍♀️
> 공유드린 작업 1. 모달 UI
> 공유드린 작업 2. 컨버터 모듈 개발

## 리뷰어님께 드리고 싶은 질문 ❓
1. 모달 UI 의 fadeIn,fadeOut 애니메이션을 컴포넌트 마운트, 언마운트 이벤트에 맞게 구현하고 싶습니다. 이를 적용할 수 있는 방법이 있을까요?
2. 슬라이드 파일을 이미지 포맷의 파일들로 변환하는 모듈 모듈화를 진행했는데, 개선 가능한 부분에 대해 여쭙고 싶습니다.