### PR TITLE
[이미림] w6_반응형_캔버스가_resize될_때_이전_사이즈의_캔버스_content를_유지할_수_있도록_수정

### DIFF
--- a/MainSlide/MainSlide.jsx
+++ b/MainSlide/MainSlide.jsx
@@ -1,0 +1,73 @@
+import React, { useEffect, useRef } from 'react';
+import PropTypes from 'prop-types';
+import S from './style';
+import { useChannelSelector, useDispatch } from '@/hooks';
+import { pxToNum } from '@/utils/dom';
+import SlideCanvas from './SlideCanvas';
+
+const MainSlide = (props) => {
+  const { page, slideUrls } = props;
+  const { slideRatioList, isPenToolActive } = useChannelSelector((state) => state);
+  const slideRatio = slideRatioList[page];
+  const dispatch = useDispatch();
+  const wrapperRef = useRef(null);
+  const imageRef = useRef(null);
+  const resizeSlide = (fitHeight) => {
+    const { current } = imageRef;
+
+    current.style.width = fitHeight ? 'auto' : '100%';
+    current.style.height = fitHeight ? '100%' : 'auto';
+    current.src = slideUrls[page];
+  };
+  const resizeCanvas = (fitHeight, wrapperWidth, wrapperHeight) => {
+    const canvasWidth = fitHeight ? wrapperHeight * slideRatio : wrapperWidth;
+    const canvasHeight = fitHeight ? wrapperHeight : wrapperWidth / slideRatio;
+
+    dispatch({
+      type: 'SET_CANVAS_SIZE',
+      payload: {
+        canvasWidth,
+        canvasHeight,
+      },
+    });
+  };
+
+  useEffect(() => {
+    const wrapperEl = wrapperRef.current;
+    const handleResize = () => {
+      window.requestAnimationFrame(() => {
+        const style = window.getComputedStyle(wrapperEl);
+        const wrapperWidth = pxToNum(style.width);
+        const wrapperHeight = pxToNum(style.height);
+        const wrapperRatio = wrapperWidth / wrapperHeight;
+        const fitHeight = wrapperRatio > slideRatio;
+
+        resizeSlide(fitHeight);
+        resizeCanvas(fitHeight, wrapperWidth, wrapperHeight);
+      });
+    };
+
+    handleResize();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [page]);
+
+  return (
+    <S.MainSlide>
+      <S.SlideWrapper ref={wrapperRef}>
+        <S.SlideImg ref={imageRef} alt="slide" />
+        {isPenToolActive && <SlideCanvas />}
+      </S.SlideWrapper>
+    </S.MainSlide>
+  );
+};
+
+MainSlide.propTypes = {
+  page: PropTypes.number.isRequired,
+  slideUrls: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default MainSlide;

--- a/MainSlide/SlideCanvas/SlideCanvas.jsx
+++ b/MainSlide/SlideCanvas/SlideCanvas.jsx
@@ -1,0 +1,122 @@
+import React, { useRef, useEffect } from 'react';
+import S from './style';
+import { useChannelSelector, useDispatch } from '@/hooks';
+
+const SlideCanvas = () => {
+  const dispatch = useDispatch();
+  const canvasRef = useRef(null);
+  const canvas = canvasRef.current;
+  const {
+    canvasSize: {
+      canvasWidth,
+      canvasHeight,
+    },
+    canvasHistory,
+  } = useChannelSelector((state) => state);
+  const tempCanvasHistory = [];
+  const prevPosition = { x: 0, y: 0 };
+  const lineStyle = {
+    lineWidth: 2,
+    lineCap: 'round',
+    strokeStyle: 'red',
+  };
+  const addCanvasHistory = (mousePositionX, mousePositionY) => {
+    const ratioX = canvasWidth / mousePositionX;
+    const ratioY = canvasHeight / mousePositionY;
+
+    tempCanvasHistory.push([ratioX, ratioY]);
+  };
+  const setPosition = (x, y) => {
+    prevPosition.x = x;
+    prevPosition.y = y;
+  };
+  const handleMouseDown = (event) => {
+    prevPosition.x = event.offsetX;
+    prevPosition.y = event.offsetY;
+  };
+  const handleMouseMove = (event) => {
+    if (event.buttons !== 1) return;
+    const { lineWidth, lineCap, strokeStyle } = lineStyle;
+    const ctx = canvas.getContext('2d');
+    ctx.beginPath();
+
+    ctx.lineWidth = lineWidth;
+    ctx.lineCap = lineCap;
+    ctx.strokeStyle = strokeStyle;
+
+    ctx.moveTo(prevPosition.x, prevPosition.y);
+    ctx.lineTo(event.offsetX, event.offsetY);
+    ctx.stroke();
+
+    setPosition(event.offsetX, event.offsetY);
+    addCanvasHistory(event.offsetX, event.offsetY);
+  };
+  const handleMouseUp = () => {
+    tempCanvasHistory.push([]);
+    dispatch({
+      type: 'UPDATE_CANVAS_HISTORY',
+      payload: { canvasHistory: [...canvasHistory, ...tempCanvasHistory] },
+    });
+  };
+
+  useEffect(() => {
+    if (canvas === null) {
+      window.dispatchEvent(new Event('resize'));
+      return;
+    }
+    canvas.addEventListener('mousemove', handleMouseMove);
+    canvas.addEventListener('mousedown', handleMouseDown);
+    canvas.addEventListener('mouseup', handleMouseUp);
+  }, [canvas, canvasWidth, canvasHeight]);
+
+  const calculatePosition = (ratioX, ratioY) => {
+    const currPositionX = canvasWidth / ratioX;
+    const currPositionY = canvasHeight / ratioY;
+
+    return { currPositionX, currPositionY };
+  };
+
+  const reDrawCanvasContent = () => {
+    const ctx = canvasRef.current.getContext('2d');
+    const newPosition = [];
+    canvasHistory.forEach((history, index) => {
+      const ratioX = history[0];
+      const ratioY = history[1];
+      const { currPositionX, currPositionY } = calculatePosition(ratioX, ratioY);
+
+      newPosition.push([currPositionX, currPositionY]);
+
+      if (index === 0) return;
+
+      const { lineWidth, lineCap, strokeStyle } = lineStyle;
+      const prevNewPosition = newPosition[index - 1];
+      const prevNewPositionX = prevNewPosition[0];
+      const prevNewPositionY = prevNewPosition[1];
+
+      ctx.lineWidth = lineWidth;
+      ctx.lineCap = lineCap;
+      ctx.strokeStyle = strokeStyle;
+
+      ctx.beginPath();
+      ctx.moveTo(prevNewPositionX, prevNewPositionY);
+      ctx.lineTo(currPositionX, currPositionY);
+      ctx.stroke();
+    });
+  };
+
+  useEffect(() => {
+    if (canvas === null) return;
+
+    reDrawCanvasContent();
+  }, [canvasWidth, canvasHeight]);
+
+  return (
+    <S.Canvas
+      ref={canvasRef}
+      width={canvasWidth}
+      height={canvasHeight}
+    />
+  );
+};
+
+export default SlideCanvas;

--- a/MainSlide/SlideCanvas/index.js
+++ b/MainSlide/SlideCanvas/index.js
@@ -1,0 +1,1 @@
+export { default } from './SlideCanvas';

--- a/MainSlide/SlideCanvas/style.jsx
+++ b/MainSlide/SlideCanvas/style.jsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+export default {
+  Canvas: styled.canvas`
+    position: absolute;
+    z-index: 900;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  `,
+};

--- a/MainSlide/index.js
+++ b/MainSlide/index.js
@@ -1,0 +1,1 @@
+export { default } from './MainSlide';

--- a/MainSlide/style.jsx
+++ b/MainSlide/style.jsx
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+import { px } from '@/styles/themeUtil';
+
+export default {
+  MainSlide: styled.div`
+    box-sizing: border-box;
+    width: 100%;
+    height: 100%;
+    padding: ${px(25)} 0 ${px(40)} 0;
+  `,
+  SlideWrapper: styled.div`
+    width:100%;
+    height:100%;
+    position:relative;
+  `,
+  SlideImg: styled.img`
+    position: absolute;
+    z-index: 100;
+    top: 50%;
+    left: 50%;
+    user-select: none;
+    border-radius: 3px;
+    box-shadow: 10px 2px 20px rgba(0, 0, 0, 0.1);
+    transform: translate(-50%, -50%);
+  `,
+};


### PR DESCRIPTION
# 반응형 캔버스가 resize 될 때, 이전 사이즈의 캔버스 content를 유지할 수 있도록 수정

## 해당 이슈 📎

- [Epic#24, Epic#26] Canvas가 resize될 때, 이전의 Canvas content를 유지할 수 있어야 한다. (#144)

## 변경 사항 🛠

### 전체화면 필기 화면
<img width="1440" alt="스크린샷 2019-12-13 오전 10 46 36" src="https://user-images.githubusercontent.com/40539104/70763130-5a916780-1d96-11ea-88aa-1f2bb0e04b15.png">


### 전체화면을 종료했을 때 필기 화면
<img width="999" alt="스크린샷 2019-12-13 오전 10 46 48" src="https://user-images.githubusercontent.com/40539104/70763051-1900bc80-1d96-11ea-8239-7dc201f07298.png">

### 더 작은 화면일 때 필기 화면
<img width="913" alt="스크린샷 2019-12-13 오전 10 49 39" src="https://user-images.githubusercontent.com/40539104/70763108-477e9780-1d96-11ea-8681-a80b201e3ac8.png">


## 리뷰어님 참고 사항 🙋‍♀️
- 이번 코드는 아직 리팩토링이 되지 않은 기능 구현에만 집중된 코드입니다 😭캔버스가 resize될 때, 이전의 캔버스 content를 유지하는 방식들을 생각해보았고, 다양한 방식을 실험적으로 시도해보다보니.. 목요일 늦은 저녁에 원하는 기능을 구현할 수 있는 방식으로 구현하게 되었습니다. 유틸로 분리될 수 있었던 코드도 아직 모두 컴포넌트 내부에 있고, 모듈화 할 수 있는 여지가 있는 컴포넌트지만 아직 모듈화를 적용하지 못하였습니다. (반성합니다 😭) 

###  궁금한 점
- 캔버스가 resize 될때 이전의 캔버스 content를 유지하는 방식을 생각하고, 원하는 기능을 구현할 때까지 정말 많은 시행 착오가 있었습니다. 그 중에서 저희가 생각한 방식은 아래와 같습니다. 저희가 고안한 방식 이외 혹시 좋은 아이디어 있으시면 추천 부탁드립니다! 현재 코드는 좌표 시스템을 사용하여 구현된 코드입니다.
    - 버퍼 캔버스 사용
    - 캔버스 context의 toDataUrl() 또는 toBlob() 를 이용해 이전 사이즈의 캔버스 content를 이미지로 저장하고, 캔버스 resize가 끝날 때 저장되었던 이미지를 canvas에 drawImg()를 이용해 그려주는 방식
    - OffscreenCanvas 사용
    - **좌표 시스템 사용 (그림이 그려지는 좌표값을 히스토리 형식으로 저장하는 방식)**
    - 이 외에도 비트맵 또는 벡터로 관리하는 방식 등

- 혹시  **좌표 시스템 사용 (그림이 그려지는 좌표값을 히스토리 형식으로 저장하는 방식)**과 같은 방식으로 구현하였을 때, 예상되는 또는 의심되는 사이드 이펙트/버그가 있을 것 같으신 지 궁금합니다.

```
제 코드를 리뷰해주셔서 정말 감사합니다. 리뷰해주신 내용은 주말부터 시작되는 리팩토링 기간에 꼭 반영하여 수정하겠습니다. 정말 감사합니다! 🤩
```