### PR TITLE
canvasHistory 상태 값을 전역으로 관리하지 않도록 수정

### DIFF
--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/MainSlide.jsx
@@ -1,14 +1,17 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PropTypes from 'prop-types';
 import S from './style';
-import { useChannelSelector, useDispatch } from '@/hooks';
+import { useChannelSelector } from '@/hooks';
 import { pxToNum } from '@/utils/dom';
 import SlideCanvas from './SlideCanvas';
 
 const MainSlide = (props) => {
   const { page, slideUrls } = props;
-  const { slideRatioList } = useChannelSelector((state) => state);
-  const dispatch = useDispatch();
+  const [canvasSize, setCanvasSize] = useState({
+    canvasWidth: 0,
+    canvasHeight: 0,
+  });
+  const { slideRatioList, dropyCanvas } = useChannelSelector((state) => state);
   const slideRatio = slideRatioList[page];
   const wrapperRef = useRef(null);
   const imageRef = useRef(null);
@@ -23,13 +26,8 @@ const MainSlide = (props) => {
     const canvasWidth = fitHeight ? wrapperHeight * slideRatio : wrapperWidth;
     const canvasHeight = fitHeight ? wrapperHeight : wrapperWidth / slideRatio;
 
-    dispatch({
-      type: 'SET_CANVAS_SIZE',
-      payload: {
-        canvasWidth,
-        canvasHeight,
-      },
-    });
+    dropyCanvas.setSize(canvasWidth, canvasHeight);
+    setCanvasSize({ canvasWidth, canvasHeight });
   };
 
   useEffect(() => {
@@ -59,7 +57,10 @@ const MainSlide = (props) => {
     <S.MainSlide>
       <S.SlideWrapper ref={wrapperRef}>
         <S.SlideImg ref={imageRef} alt="slide" />
-        <SlideCanvas />
+        <SlideCanvas
+          canvasWidth={canvasSize.canvasWidth}
+          canvasHeight={canvasSize.canvasHeight}
+        />
       </S.SlideWrapper>
     </S.MainSlide>
   );

--- a/web/src/components/channel/Slide/SlideViewer/MainSlide/SlideCanvas/SlideCanvas.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/MainSlide/SlideCanvas/SlideCanvas.jsx
@@ -1,39 +1,24 @@
 import React, { useRef, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import S from './style';
 import { useChannelSelector, useDispatch } from '@/hooks';
-import DropyCanvas from '@/utils/DropyCanvas';
 
-const SlideCanvas = () => {
+const SlideCanvas = (props) => {
+  const { canvasWidth, canvasHeight } = props;
   const canvasRef = useRef(null);
   const canvas = canvasRef.current;
   const dispatch = useDispatch();
   const {
-    canvasSize: {
-      canvasWidth,
-      canvasHeight,
-    },
-    canvasHistory,
-    toolOption,
     isEraserToolActive,
     isPenToolActive,
+    dropyCanvas,
   } = useChannelSelector((state) => state);
-  const dropyCanvas = new DropyCanvas(canvasWidth, canvasHeight);
-
-  dropyCanvas.init();
 
   useEffect(() => {
     if (canvas === null) return;
     const context = canvas.getContext('2d');
 
-    context.clearRect(0, 0, canvasWidth, canvasHeight);
-    dropyCanvas.resetTempCanvasHistory();
-
-    dispatch({
-      type: 'RESET_CANVAS_HISTORY',
-      payload: {
-        canvasHistory: [],
-      },
-    });
+    dropyCanvas.clearCanvas(context);
   }, [isEraserToolActive]);
 
   useEffect(() => {
@@ -44,40 +29,32 @@ const SlideCanvas = () => {
     if (isPenToolActive) {
       const context = canvas.getContext('2d');
       dropyCanvas.setContext(context);
-      dropyCanvas.setTool(toolOption);
       dropyCanvas.addEventListener(canvas);
     }
 
     return () => {
-      if (!isEraserToolActive) {
-        dispatch({
-          type: 'UPDATE_CANVAS_HISTORY',
-          payload: {
-            canvasHistory: [
-              ...canvasHistory,
-              ...dropyCanvas.getTempCanvasHistory(),
-            ],
-          },
-        });
-      }
       dispatch({ type: 'ERASER_TOOL_INACTIVE' });
       dropyCanvas.removeEventListener(canvas);
     };
-  }, [canvas, canvasWidth, canvasHeight, isEraserToolActive, isPenToolActive]);
+  }, [canvas, canvasWidth, canvasHeight, isPenToolActive]);
 
   useEffect(() => {
     if (canvas === null) return;
     const context = canvas.getContext('2d');
 
-    dropyCanvas.setTool(toolOption);
-    dropyCanvas.reDrawContent(canvasHistory, context);
-  }, [canvasHistory, canvasWidth, canvasHeight, canvas]);
+    dropyCanvas.reDrawContent(context);
+  }, [canvas, canvasWidth, canvasHeight]);
 
   return (
     <S.CanvasWrapper isPenToolActive={isPenToolActive}>
       {dropyCanvas.render(canvasRef)}
     </S.CanvasWrapper>
   );
+};
+
+SlideCanvas.propTypes = {
+  canvasWidth: PropTypes.number.isRequired,
+  canvasHeight: PropTypes.number.isRequired,
 };
 
 export default SlideCanvas;

--- a/web/src/components/channel/ToolBar/PenTool/PenTool.jsx
+++ b/web/src/components/channel/ToolBar/PenTool/PenTool.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import S from './style';
-import { useDispatch, useChannelSelector } from '@/hooks';
+import { useChannelSelector, useDispatch } from '@/hooks';
 
 const PenTool = () => {
   const dispatch = useDispatch();
-  const isPenToolActive = useChannelSelector((state) => state.isPenToolActive);
+  const {
+    isPenToolActive,
+    dropyCanvas,
+  } = useChannelSelector((state) => state);
   const penToolOption = {
     toolType: 'pen',
     toolStyleOption: {
@@ -14,12 +17,8 @@ const PenTool = () => {
     },
   };
   const handleOnclick = () => {
-    dispatch({
-      type: 'PEN_TOOL_ACTIVE',
-      payload: {
-        toolOption: penToolOption,
-      },
-    });
+    dropyCanvas.setToolStyle(penToolOption);
+    dispatch({ type: 'PEN_TOOL_ACTIVE' });
   };
 
   return (

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -24,6 +24,7 @@ import {
   ENTERING_CHANNEL_MESSAGGGE,
   PRESENTATION_ON,
 } from '@/constants';
+import DropyCanvas from '@/utils/DropyCanvas';
 
 const Channel = (props) => {
   const { user } = props;
@@ -35,6 +36,9 @@ const Channel = (props) => {
     openModal,
     closeModal,
   } = useModal();
+  const dropyCanvas = new DropyCanvas();
+
+  dropyCanvas.init();
 
   useEffect(() => {
     if (data && data.status === 'ok') {
@@ -63,6 +67,7 @@ const Channel = (props) => {
     channelName: channel.channelOptions.channelName,
     anonymousChat: channel.channelOptions.anonymousChat,
     emojiEffect: data.channel.channelOptions.emojiEffect,
+    dropyCanvas,
   };
 
   return (

--- a/web/src/reducers/channel.js
+++ b/web/src/reducers/channel.js
@@ -5,16 +5,6 @@ const initialChannelState = {
   isToolBarActive: false,
   isPenToolActive: false,
   isEraserToolActive: false,
-  canvasSize: {},
-  canvasHistory: [],
-  toolOption: {
-    toolType: '',
-    toolStyleOption: {
-      lineWidth: 0,
-      lineCap: '',
-      lineColor: '',
-    },
-  },
 };
 
 const channelReducer = (state, action) => {
@@ -43,7 +33,6 @@ const channelReducer = (state, action) => {
       return {
         ...state,
         isPenToolActive: !state.isPenToolActive,
-        toolOption: action.payload.toolOption,
       };
     case 'ERASER_TOOL_ACTIVE':
       return {
@@ -55,22 +44,6 @@ const channelReducer = (state, action) => {
         ...state,
         isEraserToolActive: false,
       };
-    case 'SET_CANVAS_SIZE':
-      return {
-        ...state,
-        canvasSize: action.payload,
-      };
-    case 'UPDATE_CANVAS_HISTORY':
-      return {
-        ...state,
-        canvasHistory: action.payload.canvasHistory,
-      };
-    case 'RESET_CANVAS_HISTORY':
-      return {
-        ...state,
-        canvasHistory: action.payload.canvasHistory,
-      };
-
     default:
       return state;
   }

--- a/web/src/utils/DropyCanvas/DropyCanvas.js
+++ b/web/src/utils/DropyCanvas/DropyCanvas.js
@@ -6,14 +6,11 @@ import {
 } from './utils';
 
 class DropyCanvas {
-  constructor(width, height) {
-    this.width = width;
-    this.height = height;
-  }
-
   init() {
+    this.width = 0;
+    this.height = 0;
     this.prevPosition = { x: 0, y: 0 };
-    this.tempCanvasHistory = [];
+    this.history = [];
     this.toolType = null;
     this.lineWidth = null;
     this.lineCap = null;
@@ -55,11 +52,11 @@ class DropyCanvas {
   }
 
   handleMouseUp() {
-    this.tempCanvasHistory.push([]);
+    this.history.push([]);
   }
 
   handleMouseLeave() {
-    this.tempCanvasHistory.push([]);
+    this.history.push([]);
   }
 
   addEventListener(canvasElement) {
@@ -74,7 +71,7 @@ class DropyCanvas {
     const ratioX = this.width / mousePositionX;
     const ratioY = this.height / mousePositionY;
 
-    this.tempCanvasHistory.push([ratioX, ratioY]);
+    this.history.push([ratioX, ratioY]);
   }
 
   saveMousePosition(x, y) {
@@ -86,7 +83,7 @@ class DropyCanvas {
     this.context = context;
   }
 
-  setTool(toolOption) {
+  setToolStyle(toolOption) {
     const {
       toolType,
       toolStyleOption: {
@@ -102,19 +99,27 @@ class DropyCanvas {
     this.strokeStyle = lineColor;
   }
 
-  getTempCanvasHistory() {
-    return this.tempCanvasHistory;
+  setSize(width, height) {
+    this.width = width;
+    this.height = height;
   }
 
-  resetTempCanvasHistory() {
-    this.tempCanvasHistory = [];
+  getHistory() {
+    return this.history;
   }
 
-  reDrawContent(canvasHistory, context) {
+  resetHistory() {
+    this.history = [];
+  }
+
+  clearCanvas(context) {
+    context.clearRect(0, 0, this.width, this.height);
+    this.resetHistory();
+  }
+
+  reDrawContent(context) {
     const newPosition = [];
-    canvasHistory.forEach((history, index) => {
-      const ratioX = history[0];
-      const ratioY = history[1];
+    this.history.forEach(([ratioX, ratioY], index) => {
       const { currPositionX, currPositionY } = ratioToRealPosition(
         ratioX,
         ratioY,
@@ -126,9 +131,7 @@ class DropyCanvas {
 
       if (index === 0) return;
 
-      const prevNewPosition = newPosition[index - 1];
-      const prevNewPositionX = prevNewPosition[0];
-      const prevNewPositionY = prevNewPosition[1];
+      const [prevNewPositionX, prevNewPositionY] = newPosition[index - 1];
 
       context.lineWidth = this.lineWidth;
       context.lineCap = this.lineCap;


### PR DESCRIPTION
# canvasHistory 상태 값을 전역으로 관리하지 않도록 수정

## 해당 이슈 📎

- [ 리팩토링 ] 캔버스를 그릴 때, canvasHistory 상태 값을 전역으로 관리하지 않도록 리팩토링해야 한다. (#175)

## 변경 사항 🛠
- canvasHistory를 전역으로 관리하지 않도록 수정한다.
- 채널 당 한 개의 dropyCanvas 객체를 생성하여 전역으로 관리하도록 수정한다.
- canvasHistory는 dropyCanvas 모듈 내에서 관리하도록 수정한다.

## 테스트 ✨
> 없음

## 리뷰어 참고 사항 🙋‍♀️

> 없음

