### PR TITLE
채널 페이지 렌더링 최적화 시도

### DIFF
--- a/web/src/components/channel/Chat/Chat.jsx
+++ b/web/src/components/channel/Chat/Chat.jsx
@@ -7,7 +7,7 @@ import ChatSort from './ChatSort';
 import S from './style';
 
 const ChatToggle = (props) => {
-  const { channelId, userId } = props;
+  const { channelId, userId, slideLength } = props;
   const [isClosed, setIsClosed] = useState(false);
   const [questionToggle, setQuestionToggle] = useState(false);
 
@@ -28,8 +28,13 @@ const ChatToggle = (props) => {
             channelId={channelId}
             userId={userId}
             questionToggle={questionToggle}
+            slideLength={slideLength}
           />
-          <ChatInput channelId={channelId} setQuestionToggle={setQuestionToggle} />
+          <ChatInput
+            slideLength={slideLength}
+            channelId={channelId}
+            setQuestionToggle={setQuestionToggle}
+          />
         </>
       )}
     </S.Chat>
@@ -37,24 +42,31 @@ const ChatToggle = (props) => {
 };
 
 const Chat = (props) => {
-  const { channelId, userId } = props;
+  const { channelId, userId, slideLength } = props;
 
   useInitChat(channelId);
   useChatChanged(channelId, userId);
 
   return (
-    <ChatToggle channelId={channelId} userId={userId} />
+    <ChatToggle
+      slideLength={slideLength}
+      channelId={channelId}
+      userId={userId}
+    />
   );
 };
 
 ChatToggle.propTypes = {
   channelId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
+  slideLength: PropTypes.number.isRequired,
 };
 
 Chat.propTypes = {
   channelId: PropTypes.string.isRequired,
   userId: PropTypes.string.isRequired,
+  slideLength: PropTypes.number.isRequired,
+
 };
 
 export default Chat;

--- a/web/src/components/channel/Chat/ChatInput/ChatInput.jsx
+++ b/web/src/components/channel/Chat/ChatInput/ChatInput.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   useAddChat,
-  useChannelSelector,
   useAnonymousChanged,
   useGetUserStatus,
   useDispatch,
@@ -26,13 +25,12 @@ const ChatInput = (props) => {
   const dispatch = useDispatch();
   const { mutate } = useAddChat();
   const { isAnonymous } = useGetUserStatus();
-  const { channelId, setQuestionToggle } = props;
-  const limit = useChannelSelector((state) => state.slideUrls.length);
+  const { channelId, setQuestionToggle, slideLength } = props;
   const { anonymousChat } = useAnonymousChanged(channelId);
 
   const sendMessage = () => {
     if (message === '') return;
-    const { isQuestion } = pipe(parseMessage, checkIsQuestion)({ text: message, limit });
+    const { isQuestion } = pipe(parseMessage, checkIsQuestion)({ text: message, slideLength });
 
     mutate({ variables: { channelId, message, isQuestion } });
     setMessage('');
@@ -53,19 +51,21 @@ const ChatInput = (props) => {
       payload: { isChat },
     });
   };
+  const handleAnonymous = (input, anonymousInput) => {
+    if (anonymousChat || !isAnonymous) return input;
+    return anonymousInput;
+  };
 
   return (
     <S.ChatInput>
       <S.MessageInput
-        placeholder={anonymousChat || !isAnonymous
-          ? CHAT_INPUT_PLACEHOLDER
-          : CHAT_ANONYMOUS_PLACEHOLDER}
+        placeholder={handleAnonymous(CHAT_INPUT_PLACEHOLDER, CHAT_ANONYMOUS_PLACEHOLDER)}
         onChange={handleChangeInput}
         onKeyDown={handleKeyDownInput}
         onFocus={handleFocus(true)}
         onBlur={handleFocus(false)}
         anonymousChat={!anonymousChat && isAnonymous}
-        value={message}
+        value={handleAnonymous(message, '')}
       />
       <S.SendButton
         type="button"
@@ -80,6 +80,7 @@ const ChatInput = (props) => {
 ChatInput.propTypes = {
   channelId: PropTypes.string.isRequired,
   setQuestionToggle: PropTypes.func.isRequired,
+  slideLength: PropTypes.number.isRequired,
 };
 
 export default ChatInput;

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCard.jsx
@@ -5,7 +5,6 @@ import S from './style';
 import {
   useGetQuestion,
   useDispatch,
-  useChannelSelector,
 } from '@/hooks';
 import { parseTag } from '@/utils';
 import {
@@ -20,19 +19,19 @@ const ChatCard = (props) => {
     isLiked,
     likesCount,
     handleClickLike,
+    slideLength,
   } = props;
   const dispatch = useDispatch();
-  const slideUrls = useChannelSelector((state) => state.slideUrls);
-  const tokens = useGetQuestion({ text: message, limit: slideUrls.length });
+  const tokens = useGetQuestion({ text: message, limit: slideLength });
   const handleSetPage = (token) => () => {
-    const { nextPage, isExist } = parseTag(token, slideUrls.length);
+    const { nextPage, isExist } = parseTag(token, slideLength);
     if (!isExist) return;
 
     dispatch({ type: CHANNEL_REDUCER_SET_ISSYNC, payload: { isSync: false } });
     dispatch({ type: CHANNEL_REDUCER_SET_PAGE, payload: { page: nextPage - 1 } });
   };
   const renderQuestion = () => tokens.map(({ id, token, isQtag }) => {
-    const { isExist } = parseTag(token, slideUrls.length);
+    const { isExist } = parseTag(token, slideLength);
     const noneQuestion = isQtag && !isExist ? 'disable' : 'nomal';
     const state = isQtag && isExist ? 'question' : noneQuestion;
 
@@ -74,6 +73,7 @@ ChatCard.propTypes = {
   isLiked: PropTypes.bool.isRequired,
   likesCount: PropTypes.number.isRequired,
   handleClickLike: PropTypes.func.isRequired,
+  slideLength: PropTypes.number.isRequired,
 };
 
 export default ChatCard;

--- a/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCards.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatCards/ChatCards.jsx
@@ -5,7 +5,7 @@ import ChatCard from './ChatCard';
 import S from './style';
 
 const ChatCards = (props) => {
-  const { userId, chats } = props;
+  const { userId, chats, slideLength } = props;
   const { mutate } = useLikeChat();
 
   return (
@@ -22,6 +22,7 @@ const ChatCards = (props) => {
             message={message}
             isLiked={likes.includes(userId)}
             likesCount={likes.length}
+            slideLength={slideLength}
             handleClickLike={() => mutate({ variables: { chatId: id } })}
           />
         </S.ChatLog>
@@ -41,6 +42,7 @@ ChatCards.propTypes = {
     message: PropTypes.string.isRequired,
     likes: PropTypes.arrayOf(PropTypes.string).isRequired,
   })).isRequired,
+  slideLength: PropTypes.number.isRequired,
 };
 
 export default ChatCards;

--- a/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
+++ b/web/src/components/channel/Chat/ChatLogs/ChatLogs.jsx
@@ -32,7 +32,7 @@ const scrollCommander = {
 
 const ChatLogs = (props) => {
   const scrollWrapRef = useRef(null);
-  const { userId, questionToggle } = props;
+  const { userId, questionToggle, slideLength } = props;
   const { loading, chatCache } = useGetChatsCached();
 
   if (loading) return <p>loading...</p>;
@@ -54,7 +54,11 @@ const ChatLogs = (props) => {
   return (
     <S.ChatLogs>
       <S.ScrollWrap ref={scrollWrapRef}>
-        <ChatCards userId={userId} chats={chatLogs} />
+        <ChatCards
+          userId={userId}
+          chats={chatLogs}
+          slideLength={slideLength}
+        />
       </S.ScrollWrap>
     </S.ChatLogs>
   );
@@ -63,6 +67,7 @@ const ChatLogs = (props) => {
 ChatLogs.propTypes = {
   userId: PropTypes.string.isRequired,
   questionToggle: PropTypes.bool.isRequired,
+  slideLength: PropTypes.number.isRequired,
 };
 
 export default ChatLogs;

--- a/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
+++ b/web/src/components/channel/Slide/SlideInfo/SlideInfo.jsx
@@ -24,7 +24,8 @@ const SlideInfo = (props) => {
   const [listenerCount, setListenerCount] = useState(initCountListener);
 
   useEffect(() => {
-    const listenerLength = listenerList.length === 0 ? CHANNEL_INIT_LISTENER_COUNT : listenerList.length;
+    const listenerLength = listenerList.length === 0
+      ? CHANNEL_INIT_LISTENER_COUNT : listenerList.length;
     setListenerCount(listenerLength);
   }, [listenerList]);
 

--- a/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
+++ b/web/src/components/channel/Slide/SlideViewer/SlideViewer.jsx
@@ -76,6 +76,11 @@ const SlideViewer = (props) => {
     mutate({ variables: { channelId, currentSlide: page } });
   }, [page]);
 
+  useCallback(() => {
+    if (!isMaster) return;
+    dispatch({ type: CHANNEL_REDUCER_SET_ISSYNC, payload: { isSync: false } });
+  }, []);
+
   const handleScreenOnChange = (event) => {
     setFullScreen(event);
     window.dispatchEvent(new Event('resize'));

--- a/web/src/pages/Channel/Channel.jsx
+++ b/web/src/pages/Channel/Channel.jsx
@@ -72,7 +72,11 @@ const Channel = (props) => {
       <Entrance channelId={channelId} isMaster={isMaster}>
         <S.Channel>
           <ToolBar />
-          <Chat channelId={channelId} userId={user.userId} />
+          <Chat
+            channelId={channelId}
+            userId={user.userId}
+            slideLength={channel.slideUrls.length}
+          />
           <Slide channelId={channelId} openSettingModal={openModal} />
           {data.isMaster && (
           <SettingModal

--- a/web/src/utils/optimize.js
+++ b/web/src/utils/optimize.js
@@ -1,0 +1,25 @@
+const throttle = (func, delay) => {
+  let timeout = null;
+
+  return (...args) => {
+    if (timeout) return;
+    timeout = setTimeout(() => {
+      func.call(this, ...args);
+      clearTimeout(timeout);
+      timeout = null;
+    }, delay);
+  };
+};
+
+const debounce = (func, delay) => {
+  let timeout = null;
+
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      func.call(this, ...args);
+    }, delay);
+  };
+};
+
+export { throttle, debounce };


### PR DESCRIPTION
# 채널 페이지 렌더링 최적화 시도

## 해당 이슈 📎

- 채널페이지의 슬라이드컴포넌트 렌더링 최적화 (#132)

## 변경 사항 🛠

- 채팅에서 불필요하게 컨텍스트 데이터를 사용하고 있어 제거함
- 슬라이드 리사이즈 이벤트에 불필요한 렌더링을 줄이기 위해 throttle 적용